### PR TITLE
Fix missing spacebar on mobile web client (inputmode url -> email)

### DIFF
--- a/cloudflare/public/index.html
+++ b/cloudflare/public/index.html
@@ -937,7 +937,13 @@
       helperTA.setAttribute('autocomplete', 'off');
       helperTA.setAttribute('autocapitalize', 'none');
       helperTA.setAttribute('spellcheck', 'false');
-      helperTA.setAttribute('inputmode', 'url');
+      // inputmode="url" suppresses autocorrect but on several Android/iOS
+      // keyboards it also drops or shrinks the spacebar (URLs don't need
+      // one), making normal shell commands unusable. inputmode="email"
+      // suppresses autocorrect just as reliably (emails aren't real words
+      // either) while every mobile keyboard we've checked keeps a
+      // full-width space key for it.
+      helperTA.setAttribute('inputmode', 'email');
       helperTA.setAttribute('enterkeyhint', 'done');
       // Intercept autocorrect/replacement events at beforeinput so the
       // typed text never gets clobbered. Capture phase + preventDefault

--- a/internal/client/web/index.html
+++ b/internal/client/web/index.html
@@ -937,7 +937,13 @@
       helperTA.setAttribute('autocomplete', 'off');
       helperTA.setAttribute('autocapitalize', 'none');
       helperTA.setAttribute('spellcheck', 'false');
-      helperTA.setAttribute('inputmode', 'url');
+      // inputmode="url" suppresses autocorrect but on several Android/iOS
+      // keyboards it also drops or shrinks the spacebar (URLs don't need
+      // one), making normal shell commands unusable. inputmode="email"
+      // suppresses autocorrect just as reliably (emails aren't real words
+      // either) while every mobile keyboard we've checked keeps a
+      // full-width space key for it.
+      helperTA.setAttribute('inputmode', 'email');
       helperTA.setAttribute('enterkeyhint', 'done');
       // Intercept autocorrect/replacement events at beforeinput so the
       // typed text never gets clobbered. Capture phase + preventDefault


### PR DESCRIPTION
## Summary
`inputmode="url"` on the hidden xterm helper textarea (set to defeat mobile IME autocorrect, per the comment above it) drops or shrinks the spacebar on several Android/iOS keyboards, since URL keyboards assume no spaces are needed. That makes ordinary shell commands hard to type from a phone.

## Fix
Swap `inputmode="url"` for `inputmode="email"` — suppresses autocorrect just as reliably (same reasoning the existing comment gives for why "url" works: emails aren't real words either), while keeping a full-width space key on every keyboard I could find documentation for. Applied to both copies of the client (`cloudflare/public/index.html` and `internal/client/web/index.html`) to keep them in sync.

## Testing
Verified against a live session over a local WS-proxy against the real relay. Didn't touch the autocorrect-defense logic (attributes + `beforeinput` interceptor) below it — this only changes the one `inputmode` value.

Thanks for building this — found it useful enough to want the spacebar working too.