### PR TITLE
Make relay defaults configurable for forks and local builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,12 +128,12 @@ jobs:
           if [ -n "$REMINAL_DEFAULT_RELAY" ] && [ -z "$REMINAL_DEFAULT_WEB" ]; then
             REMINAL_DEFAULT_WEB="${REMINAL_DEFAULT_RELAY%/}"
             REMINAL_DEFAULT_WEB="${REMINAL_DEFAULT_WEB%/ws}"
-            REMINAL_DEFAULT_WEB="${REMINAL_DEFAULT_WEB/wss:\/\//https://}"
-            REMINAL_DEFAULT_WEB="${REMINAL_DEFAULT_WEB/ws:\/\//http://}"
+            REMINAL_DEFAULT_WEB="${REMINAL_DEFAULT_WEB/#wss:\/\//https://}"
+            REMINAL_DEFAULT_WEB="${REMINAL_DEFAULT_WEB/#ws:\/\//http://}"
           elif [ -n "$REMINAL_DEFAULT_WEB" ] && [ -z "$REMINAL_DEFAULT_RELAY" ]; then
             REMINAL_DEFAULT_RELAY="${REMINAL_DEFAULT_WEB%/}"
-            REMINAL_DEFAULT_RELAY="${REMINAL_DEFAULT_RELAY/https:\/\//wss://}"
-            REMINAL_DEFAULT_RELAY="${REMINAL_DEFAULT_RELAY/http:\/\//ws://}/ws"
+            REMINAL_DEFAULT_RELAY="${REMINAL_DEFAULT_RELAY/#https:\/\//wss://}"
+            REMINAL_DEFAULT_RELAY="${REMINAL_DEFAULT_RELAY/#http:\/\//ws://}/ws"
           fi
           RELAY_LDFLAGS=""
           [ -n "$REMINAL_DEFAULT_RELAY" ] && RELAY_LDFLAGS="$RELAY_LDFLAGS -X github.com/reminal/reminal/internal/config.DefaultCloudRelay=${REMINAL_DEFAULT_RELAY%/}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,13 +117,28 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           VERSION: ${{ github.ref_name }}
           COMMIT: ${{ github.sha }}
+          REMINAL_DEFAULT_RELAY: ${{ vars.REMINAL_DEFAULT_RELAY }}
+          REMINAL_DEFAULT_WEB: ${{ vars.REMINAL_DEFAULT_WEB }}
         run: |
           VERSION="${VERSION#v}"
           BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           SHORT_COMMIT="${COMMIT:0:7}"
           OUT="reminal"
           [ "$GOOS" = "windows" ] && OUT="reminal.exe"
-          CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.buildDate=${BUILD_DATE} -X main.commit=${SHORT_COMMIT} -X github.com/reminal/reminal/internal/config.DefaultCloudRelay=wss://reminal-relay.futuristic.workers.dev/ws -X github.com/reminal/reminal/internal/config.DefaultCloudWeb=https://reminal-relay.futuristic.workers.dev" -o "$OUT" ./cmd/reminal
+          if [ -n "$REMINAL_DEFAULT_RELAY" ] && [ -z "$REMINAL_DEFAULT_WEB" ]; then
+            REMINAL_DEFAULT_WEB="${REMINAL_DEFAULT_RELAY%/}"
+            REMINAL_DEFAULT_WEB="${REMINAL_DEFAULT_WEB%/ws}"
+            REMINAL_DEFAULT_WEB="${REMINAL_DEFAULT_WEB/wss:\/\//https://}"
+            REMINAL_DEFAULT_WEB="${REMINAL_DEFAULT_WEB/ws:\/\//http://}"
+          elif [ -n "$REMINAL_DEFAULT_WEB" ] && [ -z "$REMINAL_DEFAULT_RELAY" ]; then
+            REMINAL_DEFAULT_RELAY="${REMINAL_DEFAULT_WEB%/}"
+            REMINAL_DEFAULT_RELAY="${REMINAL_DEFAULT_RELAY/https:\/\//wss://}"
+            REMINAL_DEFAULT_RELAY="${REMINAL_DEFAULT_RELAY/http:\/\//ws://}/ws"
+          fi
+          RELAY_LDFLAGS=""
+          [ -n "$REMINAL_DEFAULT_RELAY" ] && RELAY_LDFLAGS="$RELAY_LDFLAGS -X github.com/reminal/reminal/internal/config.DefaultCloudRelay=${REMINAL_DEFAULT_RELAY%/}"
+          [ -n "$REMINAL_DEFAULT_WEB" ] && RELAY_LDFLAGS="$RELAY_LDFLAGS -X github.com/reminal/reminal/internal/config.DefaultCloudWeb=${REMINAL_DEFAULT_WEB%/}"
+          CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} -X main.buildDate=${BUILD_DATE} -X main.commit=${SHORT_COMMIT}${RELAY_LDFLAGS}" -o "$OUT" ./cmd/reminal
           echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
 
       - name: Build capture helper (macOS)

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Binaries
 /dist/
 /reminal
+/reminal.build.env
 
 # Go
 /vendor/

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ relay: build
 	./dist/reminal relay
 
 run: build
-	REMINAL_RELAY=ws://localhost:8080/ws ./dist/reminal
+	REMINAL_LOCAL=1 ./dist/reminal
 
 clean:
 	rm -rf dist/

--- a/README.md
+++ b/README.md
@@ -287,22 +287,36 @@ npx wrangler login
 npm run deploy
 ```
 
-Then point `DefaultCloudRelay` / `DefaultCloudWeb` in `internal/config/config.go` at your `workers.dev` URL and rebuild. Full guide in [cloudflare/README.md](cloudflare/README.md).
+Then copy `reminal.build.env.example` to the gitignored
+`reminal.build.env`, put your `workers.dev` URL there, and run
+`./scripts/build.sh`. No source edit is needed. Full guide in
+[cloudflare/README.md](cloudflare/README.md).
 
 ---
 
 ## Local development
 
 ```bash
+# Build once; source builds retain the upstream public relay by default
+./scripts/build.sh
+
 # Terminal 1 — your own relay on localhost:8080
-reminal relay
+./dist/reminal relay
 
 # Terminal 2 — share a session via the local relay
-REMINAL_LOCAL=1 reminal
+REMINAL_LOCAL=1 ./dist/reminal
 
 # Terminal 3 — connect from another shell or the browser
-REMINAL_LOCAL=1 reminal --connect <session_id> --pin <pin>
+REMINAL_LOCAL=1 ./dist/reminal connect <session_id> <pin>
 # or http://localhost:8080/?s=<session_id>
+```
+
+To test against a remote relay without rebuilding, set either runtime URL;
+reminal derives its counterpart automatically:
+
+```bash
+REMINAL_RELAY=wss://your-relay.example/ws ./dist/reminal
+# or: REMINAL_WEB=https://your-relay.example ./dist/reminal
 ```
 
 ---
@@ -372,8 +386,8 @@ Sessions resolve by **exact id, exact name, unique id prefix, or unique substrin
 
 | Variable | Default | What it does |
 |---|---|---|
-| `REMINAL_RELAY` | Cloudflare relay URL | Override the relay WebSocket base URL |
-| `REMINAL_WEB` | Cloudflare web URL | Override the web UI URL shown in the banner |
+| `REMINAL_RELAY` | Upstream public relay | Relay WebSocket base URL; also derives `REMINAL_WEB` when that is unset |
+| `REMINAL_WEB` | Upstream public web UI | Web UI URL; also derives `REMINAL_RELAY` when that is unset |
 | `REMINAL_LOCAL` | — | Set to `1` to point everything at `localhost` |
 | `REMINAL_OWNERS_DIR` | `/etc/reminal` (`%ProgramData%\reminal` on Windows) | Where the machine's owner list lives (the admin-gated trust store) — override for tests or unusual layouts |
 | `REMINAL_NO_KEEP_AWAKE` | — | Set to `1` to let the host sleep while reminal runs (defaults to keeping it awake via `caffeinate` / `systemd-inhibit` / `SetThreadExecutionState`) |
@@ -383,6 +397,14 @@ Sessions resolve by **exact id, exact name, unique id prefix, or unique substrin
 | `SHELL` | `$SHELL`, then probes `/bin/zsh`, `/bin/bash`, `/bin/sh` (Windows: `pwsh` → `powershell` → `cmd`) | Which shell to spawn inside the session |
 
 Installs to `~/.local/bin/reminal` (macOS/Linux) or `%LOCALAPPDATA%\Programs\reminal` (Windows) — no sudo/admin needed. Apple Silicon, x86_64, and Windows ARM64. Build from source with `./scripts/build.sh` (Go 1.25+, Swift toolchain on macOS for the native capture helper); on Windows it's a plain `go build ./cmd/reminal`.
+
+For a persistent custom default in local builds, copy
+`reminal.build.env.example` to `reminal.build.env` and set
+`REMINAL_DEFAULT_RELAY` and/or `REMINAL_DEFAULT_WEB`. The local file is ignored
+by git. Release workflows use repository variables with the same names, so
+forks can publish their own defaults; when those variables are absent, the
+upstream defaults remain intact so ordinary contributor and upstream builds
+continue to work.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,8 @@ Installs to `~/.local/bin/reminal` (macOS/Linux) or `%LOCALAPPDATA%\Programs\rem
 For a persistent custom default in local builds, copy
 `reminal.build.env.example` to `reminal.build.env` and set
 `REMINAL_DEFAULT_RELAY` and/or `REMINAL_DEFAULT_WEB`. The local file is ignored
-by git. Release workflows use repository variables with the same names, so
+by git and is parsed as inert `KEY=VALUE` data (not executed as shell code).
+Release workflows use repository variables with the same names, so
 forks can publish their own defaults; when those variables are absent, the
 upstream defaults remain intact so ordinary contributor and upstream builds
 continue to work.

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -10,23 +10,36 @@ Requires a Cloudflare **free** account. Durable Objects use the SQLite backend (
 cd cloudflare
 npm install
 npx wrangler login   # or: export CLOUDFLARE_API_TOKEN=...
+# If your login can access multiple accounts:
+export CLOUDFLARE_ACCOUNT_ID=your_account_id
 npm run deploy
 ```
 
 After deploy, wrangler prints your URL, e.g. `https://reminal-relay.<account>.workers.dev`.
 
-Update the default in `internal/config/config.go`:
-
-```go
-DefaultCloudRelay = "wss://reminal-relay.<account>.workers.dev/ws"
-DefaultCloudWeb   = "https://reminal-relay.<account>.workers.dev"
-```
-
-Or set at build time:
+For a persistent default in binaries built from this checkout, create the
+gitignored build configuration:
 
 ```bash
-go build -ldflags "-X github.com/reminal/reminal/internal/config.DefaultCloudRelay=wss://your-url/ws -X github.com/reminal/reminal/internal/config.DefaultCloudWeb=https://your-url" -o reminal ./cmd/reminal
+cd .. # repository root, if you are still in cloudflare/
+cp reminal.build.env.example reminal.build.env
+# edit reminal.build.env with your deployed URL, then:
+./scripts/build.sh
 ```
+
+You can also configure one run without rebuilding (setting either URL is
+enough; reminal derives the other):
+
+```bash
+REMINAL_RELAY=wss://your-url/ws ./dist/reminal
+# or: REMINAL_WEB=https://your-url ./dist/reminal
+```
+
+`REMINAL_DEFAULT_RELAY` and `REMINAL_DEFAULT_WEB` are build-time inputs used by
+`scripts/build.sh`; `REMINAL_RELAY` and `REMINAL_WEB` are runtime overrides.
+Plain source builds retain the upstream public relay. GitHub releases optionally
+read the build-time values from repository Actions variables of the same names;
+without them, upstream release behavior is unchanged.
 
 Optional: add a custom domain in the Cloudflare dashboard (free).
 
@@ -35,7 +48,7 @@ Optional: add a custom domain in the Cloudflare dashboard (free).
 ```bash
 npm run dev
 # In another terminal:
-REMINAL_RELAY=ws://localhost:8787/ws REMINAL_WEB=http://localhost:8787 reminal
+REMINAL_RELAY=ws://localhost:8787/ws ./dist/reminal
 ```
 
 ## Cost

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -10,8 +10,9 @@ Requires a Cloudflare **free** account. Durable Objects use the SQLite backend (
 cd cloudflare
 npm install
 npx wrangler login   # or: export CLOUDFLARE_API_TOKEN=...
-# If your login can access multiple accounts:
-export CLOUDFLARE_ACCOUNT_ID=your_account_id
+# Forks: replace account_id in wrangler.toml with your Cloudflare account ID.
+# The upstream value is deliberately pinned to prevent accidental production
+# deployments to whichever account happens to be authenticated.
 npm run deploy
 ```
 
@@ -40,6 +41,9 @@ REMINAL_RELAY=wss://your-url/ws ./dist/reminal
 Plain source builds retain the upstream public relay. GitHub releases optionally
 read the build-time values from repository Actions variables of the same names;
 without them, upstream release behavior is unchanged.
+
+`reminal.build.env` is parsed as inert `KEY=VALUE` data. Only the two documented
+build-default keys are accepted; it is not sourced or executed as shell code.
 
 Optional: add a custom domain in the Cloudflare dashboard (free).
 

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -2,10 +2,9 @@ name = "reminal-relay"
 main = "src/index.ts"
 compatibility_date = "2024-11-01"
 compatibility_flags = ["nodejs_compat"]
-# Pinned so `wrangler deploy` errors out instead of silently shipping
-# to whichever Cloudflare account happens to be logged in. Belongs to
-# harshalg98@gmail.com (the everything-account).
-account_id = "0cd85a1166e44b17571b7457040d18ae"
+# Wrangler uses the authenticated account. If that login can access multiple
+# accounts, export CLOUDFLARE_ACCOUNT_ID before deploy instead of committing a
+# contributor-specific account id here.
 
 [durable_objects]
 bindings = [

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -2,9 +2,11 @@ name = "reminal-relay"
 main = "src/index.ts"
 compatibility_date = "2024-11-01"
 compatibility_flags = ["nodejs_compat"]
-# Wrangler uses the authenticated account. If that login can access multiple
-# accounts, export CLOUDFLARE_ACCOUNT_ID before deploy instead of committing a
-# contributor-specific account id here.
+# Pinned so `wrangler deploy` errors out instead of silently shipping
+# to whichever Cloudflare account happens to be logged in. Belongs to
+# harshalg98@gmail.com (the everything-account). Forks must replace this value
+# with their own account ID before deploying.
+account_id = "0cd85a1166e44b17571b7457040d18ae"
 
 [durable_objects]
 bindings = [

--- a/cmd/reminal/main.go
+++ b/cmd/reminal/main.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/reminal/reminal/internal/client"
+	"github.com/reminal/reminal/internal/config"
 	"github.com/reminal/reminal/internal/keepawake"
 	"github.com/reminal/reminal/internal/proc"
 	"github.com/reminal/reminal/internal/pty"
@@ -45,6 +46,10 @@ var (
 func main() {
 	// Make the console render ANSI escapes (no-op outside Windows/conhost).
 	enableVTConsole()
+	if err := config.ValidateRelayURLs(); err != nil {
+		fmt.Fprintf(os.Stderr, "configuration error: %v\n", err)
+		os.Exit(2)
+	}
 
 	// Hot-restart resume path. The previous binary image hit
 	// syscall.Exec on us with REMINAL_RESUME=1 + session credentials in

--- a/cmd/reminal/main.go
+++ b/cmd/reminal/main.go
@@ -709,8 +709,8 @@ func printHelp() {
 	})
 
 	helpTable(w, "Environment", []helpRow{
-		{"REMINAL_RELAY", "Override relay URL (default: hosted Cloudflare relay)"},
-		{"REMINAL_WEB", "Override web UI URL"},
+		{"REMINAL_RELAY", "Relay WebSocket URL (overrides any build default)"},
+		{"REMINAL_WEB", "Web UI URL (overrides any build default)"},
 		{"REMINAL_LOCAL", "Set to 1 to use a localhost relay (with reminal relay)"},
 		{"REMINAL_NO_KEEP_AWAKE", "Set to 1 to let the host sleep while reminal runs"},
 		{"REMINAL_DEBUG", "Set to 1 to append raw error detail to status lines"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -24,11 +25,9 @@ const (
 // last-resort POSIX fallback that exists on every Unix.
 var shellCandidates = []string{"/bin/zsh", "/bin/bash", "/bin/sh"}
 
-// Set at build time: -ldflags "-X github.com/reminal/reminal/internal/config.DefaultCloudRelay=wss://..."
-// Pointed at the futuristic.workers.dev subdomain (harshalg98@gmail.com's
-// Cloudflare account) since v0.6.3 — the original reminal.workers.dev
-// subdomain on the other account got persistently throttled by
-// Cloudflare's workers.dev edge anti-abuse rules.
+// Upstream defaults keep a plain source build compatible with the public
+// service. Forks and release builders can replace either value with -ldflags;
+// runtime REMINAL_RELAY / REMINAL_WEB and REMINAL_LOCAL take precedence.
 var (
 	DefaultCloudRelay = "wss://reminal-relay.futuristic.workers.dev/ws"
 	DefaultCloudWeb   = "https://reminal-relay.futuristic.workers.dev"
@@ -41,7 +40,15 @@ func RelayWS() string {
 	if os.Getenv("REMINAL_LOCAL") == "1" {
 		return DefaultLocalRelay
 	}
-	return DefaultCloudRelay
+	// A single runtime URL is enough: keep links and sockets on the same host
+	// instead of falling back to a differently compiled-in service.
+	if v := os.Getenv("REMINAL_WEB"); v != "" {
+		return relayFromWeb(v)
+	}
+	if DefaultCloudRelay != "" {
+		return strings.TrimRight(DefaultCloudRelay, "/")
+	}
+	return relayFromWeb(DefaultCloudWeb)
 }
 
 func WebURL() string {
@@ -51,7 +58,51 @@ func WebURL() string {
 	if os.Getenv("REMINAL_LOCAL") == "1" {
 		return DefaultLocalWeb
 	}
-	return DefaultCloudWeb
+	if v := os.Getenv("REMINAL_RELAY"); v != "" {
+		return webFromRelay(v)
+	}
+	if DefaultCloudWeb != "" {
+		return strings.TrimRight(DefaultCloudWeb, "/")
+	}
+	return webFromRelay(DefaultCloudRelay)
+}
+
+func relayFromWeb(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	switch u.Scheme {
+	case "https":
+		u.Scheme = "wss"
+	case "http":
+		u.Scheme = "ws"
+	case "wss", "ws":
+	default:
+		return ""
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/ws"
+	u.RawQuery, u.Fragment = "", ""
+	return u.String()
+}
+
+func webFromRelay(raw string) string {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	switch u.Scheme {
+	case "wss":
+		u.Scheme = "https"
+	case "ws":
+		u.Scheme = "http"
+	case "https", "http":
+	default:
+		return ""
+	}
+	u.Path = strings.TrimSuffix(strings.TrimRight(u.Path, "/"), "/ws")
+	u.RawQuery, u.Fragment = "", ""
+	return strings.TrimRight(u.String(), "/")
 }
 
 func SessionWS(sessionID, role string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,10 @@ var (
 
 func RelayWS() string {
 	if v := os.Getenv("REMINAL_RELAY"); v != "" {
-		return strings.TrimRight(v, "/")
+		if normalized, err := normalizeEndpoint(v, "ws", "wss"); err == nil {
+			return strings.TrimRight(normalized, "/")
+		}
+		return defaultRelayWS()
 	}
 	if os.Getenv("REMINAL_LOCAL") == "1" {
 		return DefaultLocalRelay
@@ -43,66 +46,135 @@ func RelayWS() string {
 	// A single runtime URL is enough: keep links and sockets on the same host
 	// instead of falling back to a differently compiled-in service.
 	if v := os.Getenv("REMINAL_WEB"); v != "" {
-		return relayFromWeb(v)
+		if relay, err := relayFromWeb(v); err == nil {
+			return relay
+		}
 	}
-	if DefaultCloudRelay != "" {
-		return strings.TrimRight(DefaultCloudRelay, "/")
-	}
-	return relayFromWeb(DefaultCloudWeb)
+	return defaultRelayWS()
 }
 
 func WebURL() string {
 	if v := os.Getenv("REMINAL_WEB"); v != "" {
-		return strings.TrimRight(v, "/")
+		if normalized, err := normalizeEndpoint(v, "http", "https"); err == nil {
+			return strings.TrimRight(normalized, "/")
+		}
+		return defaultWebURL()
 	}
 	if os.Getenv("REMINAL_LOCAL") == "1" {
 		return DefaultLocalWeb
 	}
 	if v := os.Getenv("REMINAL_RELAY"); v != "" {
-		return webFromRelay(v)
+		if web, err := webFromRelay(v); err == nil {
+			return web
+		}
 	}
-	if DefaultCloudWeb != "" {
-		return strings.TrimRight(DefaultCloudWeb, "/")
-	}
-	return webFromRelay(DefaultCloudRelay)
+	return defaultWebURL()
 }
 
-func relayFromWeb(raw string) string {
-	u, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil || u.Host == "" {
-		return ""
+// ValidateRelayURLs catches malformed runtime and build-time endpoints before
+// the dialer turns them into an unrelated, difficult-to-diagnose network error.
+// Accessors still fall back to a valid compiled counterpart so library callers
+// never receive an empty URL, but the CLI calls this at startup and fails loud.
+func ValidateRelayURLs() error {
+	if v := os.Getenv("REMINAL_RELAY"); v != "" {
+		if _, err := normalizeEndpoint(v, "ws", "wss"); err != nil {
+			return fmt.Errorf("invalid REMINAL_RELAY: %w", err)
+		}
 	}
+	if v := os.Getenv("REMINAL_WEB"); v != "" {
+		if _, err := normalizeEndpoint(v, "http", "https"); err != nil {
+			return fmt.Errorf("invalid REMINAL_WEB: %w", err)
+		}
+	}
+	if os.Getenv("REMINAL_RELAY") != "" || os.Getenv("REMINAL_WEB") != "" || os.Getenv("REMINAL_LOCAL") == "1" {
+		return nil
+	}
+	if DefaultCloudRelay != "" {
+		if _, err := normalizeEndpoint(DefaultCloudRelay, "ws", "wss"); err != nil {
+			return fmt.Errorf("invalid compiled relay default: %w", err)
+		}
+	}
+	if DefaultCloudWeb != "" {
+		if _, err := normalizeEndpoint(DefaultCloudWeb, "http", "https"); err != nil {
+			return fmt.Errorf("invalid compiled web default: %w", err)
+		}
+	}
+	if DefaultCloudRelay == "" && DefaultCloudWeb == "" {
+		return fmt.Errorf("no relay URL configured")
+	}
+	return nil
+}
+
+func defaultRelayWS() string {
+	if DefaultCloudRelay != "" {
+		if normalized, err := normalizeEndpoint(DefaultCloudRelay, "ws", "wss"); err == nil {
+			return strings.TrimRight(normalized, "/")
+		}
+	}
+	if relay, err := relayFromWeb(DefaultCloudWeb); err == nil {
+		return relay
+	}
+	return ""
+}
+
+func defaultWebURL() string {
+	if DefaultCloudWeb != "" {
+		if normalized, err := normalizeEndpoint(DefaultCloudWeb, "http", "https"); err == nil {
+			return strings.TrimRight(normalized, "/")
+		}
+	}
+	if web, err := webFromRelay(DefaultCloudRelay); err == nil {
+		return web
+	}
+	return ""
+}
+
+func relayFromWeb(raw string) (string, error) {
+	normalized, err := normalizeEndpoint(raw, "http", "https")
+	if err != nil {
+		return "", err
+	}
+	u, _ := url.Parse(normalized)
 	switch u.Scheme {
 	case "https":
 		u.Scheme = "wss"
 	case "http":
 		u.Scheme = "ws"
-	case "wss", "ws":
-	default:
-		return ""
 	}
 	u.Path = strings.TrimRight(u.Path, "/") + "/ws"
 	u.RawQuery, u.Fragment = "", ""
-	return u.String()
+	return u.String(), nil
 }
 
-func webFromRelay(raw string) string {
-	u, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil || u.Host == "" {
-		return ""
+func webFromRelay(raw string) (string, error) {
+	normalized, err := normalizeEndpoint(raw, "ws", "wss")
+	if err != nil {
+		return "", err
 	}
+	u, _ := url.Parse(normalized)
 	switch u.Scheme {
 	case "wss":
 		u.Scheme = "https"
 	case "ws":
 		u.Scheme = "http"
-	case "https", "http":
-	default:
-		return ""
 	}
 	u.Path = strings.TrimSuffix(strings.TrimRight(u.Path, "/"), "/ws")
 	u.RawQuery, u.Fragment = "", ""
-	return strings.TrimRight(u.String(), "/")
+	return strings.TrimRight(u.String(), "/"), nil
+}
+
+func normalizeEndpoint(raw string, schemes ...string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return "", fmt.Errorf("expected an absolute URL with a host")
+	}
+	for _, scheme := range schemes {
+		if u.Scheme == scheme {
+			return u.String(), nil
+		}
+	}
+	return "", fmt.Errorf("expected %s URL", strings.Join(schemes, " or "))
 }
 
 func SessionWS(sessionID, role string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,75 @@
+package config
+
+import "testing"
+
+func withCloudDefaults(t *testing.T, relay, web string) {
+	t.Helper()
+	oldRelay, oldWeb := DefaultCloudRelay, DefaultCloudWeb
+	DefaultCloudRelay, DefaultCloudWeb = relay, web
+	t.Cleanup(func() {
+		DefaultCloudRelay, DefaultCloudWeb = oldRelay, oldWeb
+	})
+	t.Setenv("REMINAL_RELAY", "")
+	t.Setenv("REMINAL_WEB", "")
+	t.Setenv("REMINAL_LOCAL", "")
+}
+
+func TestUpstreamDefaultsRemainUsable(t *testing.T) {
+	withCloudDefaults(t,
+		"wss://reminal-relay.futuristic.workers.dev/ws",
+		"https://reminal-relay.futuristic.workers.dev")
+	if got := RelayWS(); got != "wss://reminal-relay.futuristic.workers.dev/ws" {
+		t.Fatalf("RelayWS() = %q", got)
+	}
+	if got := WebURL(); got != "https://reminal-relay.futuristic.workers.dev" {
+		t.Fatalf("WebURL() = %q", got)
+	}
+}
+
+func TestRuntimeRelayDerivesWebURL(t *testing.T) {
+	withCloudDefaults(t, "wss://compiled.example/ws", "https://compiled.example")
+	t.Setenv("REMINAL_RELAY", "wss://mine.example/prefix/ws/")
+	if got := RelayWS(); got != "wss://mine.example/prefix/ws" {
+		t.Fatalf("RelayWS() = %q", got)
+	}
+	if got := WebURL(); got != "https://mine.example/prefix" {
+		t.Fatalf("WebURL() = %q, want runtime relay counterpart", got)
+	}
+}
+
+func TestRuntimeWebDerivesRelayURL(t *testing.T) {
+	withCloudDefaults(t, "wss://compiled.example/ws", "https://compiled.example")
+	t.Setenv("REMINAL_WEB", "http://127.0.0.1:8787/base/")
+	if got := WebURL(); got != "http://127.0.0.1:8787/base" {
+		t.Fatalf("WebURL() = %q", got)
+	}
+	if got := RelayWS(); got != "ws://127.0.0.1:8787/base/ws" {
+		t.Fatalf("RelayWS() = %q, want runtime web counterpart", got)
+	}
+}
+
+func TestSingleBuildDefaultDerivesCounterpart(t *testing.T) {
+	t.Run("relay", func(t *testing.T) {
+		withCloudDefaults(t, "wss://relay.example/ws", "")
+		if got := WebURL(); got != "https://relay.example" {
+			t.Fatalf("WebURL() = %q", got)
+		}
+	})
+	t.Run("web", func(t *testing.T) {
+		withCloudDefaults(t, "", "https://relay.example")
+		if got := RelayWS(); got != "wss://relay.example/ws" {
+			t.Fatalf("RelayWS() = %q", got)
+		}
+	})
+}
+
+func TestLocalRelay(t *testing.T) {
+	withCloudDefaults(t, "wss://compiled.example/ws", "https://compiled.example")
+	t.Setenv("REMINAL_LOCAL", "1")
+	if got := RelayWS(); got != DefaultLocalRelay {
+		t.Fatalf("RelayWS() = %q, want %q", got, DefaultLocalRelay)
+	}
+	if got := WebURL(); got != DefaultLocalWeb {
+		t.Fatalf("WebURL() = %q, want %q", got, DefaultLocalWeb)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func withCloudDefaults(t *testing.T, relay, web string) {
 	t.Helper()
@@ -71,5 +74,37 @@ func TestLocalRelay(t *testing.T) {
 	}
 	if got := WebURL(); got != DefaultLocalWeb {
 		t.Fatalf("WebURL() = %q, want %q", got, DefaultLocalWeb)
+	}
+}
+
+func TestInvalidRuntimeURLsFailValidationAndDoNotLeakEmptyValues(t *testing.T) {
+	t.Run("web URL", func(t *testing.T) {
+		withCloudDefaults(t, "wss://compiled.example/ws", "https://compiled.example")
+		t.Setenv("REMINAL_WEB", "example.com")
+		if err := ValidateRelayURLs(); err == nil || !strings.Contains(err.Error(), "REMINAL_WEB") {
+			t.Fatalf("ValidateRelayURLs() = %v, want REMINAL_WEB error", err)
+		}
+		if got := RelayWS(); got != "wss://compiled.example/ws" {
+			t.Fatalf("RelayWS() = %q, want safe compiled fallback", got)
+		}
+	})
+
+	t.Run("relay scheme", func(t *testing.T) {
+		withCloudDefaults(t, "wss://compiled.example/ws", "https://compiled.example")
+		t.Setenv("REMINAL_RELAY", "ftp://relay.example/ws")
+		if err := ValidateRelayURLs(); err == nil || !strings.Contains(err.Error(), "REMINAL_RELAY") {
+			t.Fatalf("ValidateRelayURLs() = %v, want REMINAL_RELAY error", err)
+		}
+		if got := WebURL(); got != "https://compiled.example" {
+			t.Fatalf("WebURL() = %q, want safe compiled fallback", got)
+		}
+	})
+}
+
+func TestLocalModeDoesNotRequireCloudDefaults(t *testing.T) {
+	withCloudDefaults(t, "", "")
+	t.Setenv("REMINAL_LOCAL", "1")
+	if err := ValidateRelayURLs(); err != nil {
+		t.Fatalf("ValidateRelayURLs() = %v in local mode", err)
 	}
 }

--- a/reminal.build.env.example
+++ b/reminal.build.env.example
@@ -1,0 +1,6 @@
+# Optional defaults embedded by ./scripts/build.sh.
+# Copy this file to reminal.build.env (gitignored), then use your own relay URL.
+# You may set only one value; reminal derives the matching WebSocket/web URL.
+
+REMINAL_DEFAULT_RELAY=wss://your-relay.example/ws
+REMINAL_DEFAULT_WEB=https://your-relay.example

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,8 +12,26 @@ ENV_WEB_SET="${REMINAL_DEFAULT_WEB+x}"
 ENV_RELAY="${REMINAL_DEFAULT_RELAY:-}"
 ENV_WEB="${REMINAL_DEFAULT_WEB:-}"
 if [[ -f "$BUILD_CONFIG" ]]; then
-  # shellcheck disable=SC1090
-  source "$BUILD_CONFIG"
+  # Parse inert KEY=VALUE data rather than sourcing shell code. Keep the
+  # allowlist deliberately small so a typo cannot silently change the build.
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%$'\r'}"
+    [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]] && continue
+    if [[ "$line" != *=* ]]; then
+      echo "Invalid build config line in ${BUILD_CONFIG}: ${line}" >&2
+      exit 2
+    fi
+    key="${line%%=*}"
+    value="${line#*=}"
+    case "$key" in
+      REMINAL_DEFAULT_RELAY) REMINAL_DEFAULT_RELAY="$value" ;;
+      REMINAL_DEFAULT_WEB) REMINAL_DEFAULT_WEB="$value" ;;
+      *)
+        echo "Unsupported build config key in ${BUILD_CONFIG}: ${key}" >&2
+        exit 2
+        ;;
+    esac
+  done < "$BUILD_CONFIG"
 fi
 # An explicit command environment has higher precedence than the convenience
 # file (including an explicitly empty value used to disable one file entry).

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,18 +1,76 @@
 #!/bin/bash
 set -euo pipefail
 
-VERSION="${VERSION:-1.12.3}"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Personal/self-hosted relay defaults live outside version control. Copy
+# reminal.build.env.example to reminal.build.env, or point this at another file.
+BUILD_CONFIG="${REMINAL_BUILD_CONFIG:-${ROOT}/reminal.build.env}"
+ENV_RELAY_SET="${REMINAL_DEFAULT_RELAY+x}"
+ENV_WEB_SET="${REMINAL_DEFAULT_WEB+x}"
+ENV_RELAY="${REMINAL_DEFAULT_RELAY:-}"
+ENV_WEB="${REMINAL_DEFAULT_WEB:-}"
+if [[ -f "$BUILD_CONFIG" ]]; then
+  # shellcheck disable=SC1090
+  source "$BUILD_CONFIG"
+fi
+# An explicit command environment has higher precedence than the convenience
+# file (including an explicitly empty value used to disable one file entry).
+if [[ -n "$ENV_RELAY_SET" ]]; then
+  REMINAL_DEFAULT_RELAY="$ENV_RELAY"
+  [[ -z "$ENV_WEB_SET" ]] && REMINAL_DEFAULT_WEB=""
+fi
+if [[ -n "$ENV_WEB_SET" ]]; then
+  REMINAL_DEFAULT_WEB="$ENV_WEB"
+  [[ -z "$ENV_RELAY_SET" ]] && REMINAL_DEFAULT_RELAY=""
+fi
+
+# Local/fork builds must not masquerade as an old upstream release: doing so
+# makes the startup updater offer to replace the customized binary. Release CI
+# passes VERSION explicitly, while an ordinary local build stays "dev" and
+# intentionally skips upstream self-update checks.
+VERSION="${VERSION:-dev}"
 OUTPUT="${OUTPUT:-dist/reminal}"
 
 mkdir -p dist
 
-RELAY_LDFLAGS="-X github.com/reminal/reminal/internal/config.DefaultCloudRelay=wss://reminal-relay.futuristic.workers.dev/ws -X github.com/reminal/reminal/internal/config.DefaultCloudWeb=https://reminal-relay.futuristic.workers.dev"
+DEFAULT_RELAY="${REMINAL_DEFAULT_RELAY:-}"
+DEFAULT_WEB="${REMINAL_DEFAULT_WEB:-}"
+if [[ -n "$DEFAULT_RELAY" && ! "$DEFAULT_RELAY" =~ ^wss?:// ]]; then
+  echo "REMINAL_DEFAULT_RELAY must start with ws:// or wss://" >&2
+  exit 2
+fi
+if [[ -n "$DEFAULT_WEB" && ! "$DEFAULT_WEB" =~ ^https?:// ]]; then
+  echo "REMINAL_DEFAULT_WEB must start with http:// or https://" >&2
+  exit 2
+fi
+# Build defaults replace the upstream pair together. When only one is supplied,
+# derive the other so a fork never opens sockets on one relay while printing
+# links for another.
+if [[ -n "$DEFAULT_RELAY" && -z "$DEFAULT_WEB" ]]; then
+  DEFAULT_WEB="${DEFAULT_RELAY%/}"
+  DEFAULT_WEB="${DEFAULT_WEB%/ws}"
+  DEFAULT_WEB="${DEFAULT_WEB/#wss:\/\//https://}"
+  DEFAULT_WEB="${DEFAULT_WEB/#ws:\/\//http://}"
+elif [[ -n "$DEFAULT_WEB" && -z "$DEFAULT_RELAY" ]]; then
+  DEFAULT_RELAY="${DEFAULT_WEB%/}"
+  DEFAULT_RELAY="${DEFAULT_RELAY/#https:\/\//wss://}"
+  DEFAULT_RELAY="${DEFAULT_RELAY/#http:\/\//ws://}/ws"
+fi
 COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-BUILD_LDFLAGS="-X main.buildDate=${BUILD_DATE} -X main.commit=${COMMIT}"
+LDFLAGS=(-s -w -X "main.version=${VERSION}" -X "main.buildDate=${BUILD_DATE}" -X "main.commit=${COMMIT}")
+[[ -n "$DEFAULT_RELAY" ]] && LDFLAGS+=(-X "github.com/reminal/reminal/internal/config.DefaultCloudRelay=${DEFAULT_RELAY%/}")
+[[ -n "$DEFAULT_WEB" ]] && LDFLAGS+=(-X "github.com/reminal/reminal/internal/config.DefaultCloudWeb=${DEFAULT_WEB%/}")
 
 echo "Building reminal ${VERSION}..."
-CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=${VERSION} ${BUILD_LDFLAGS} ${RELAY_LDFLAGS}" -o "${OUTPUT}" ./cmd/reminal
+if [[ -n "$DEFAULT_RELAY" || -n "$DEFAULT_WEB" ]]; then
+  echo "Embedding configured relay defaults from ${BUILD_CONFIG} / environment."
+else
+  echo "Using the upstream relay defaults from internal/config (override with reminal.build.env)."
+fi
+CGO_ENABLED=0 go build -trimpath -ldflags "${LDFLAGS[*]}" -o "${OUTPUT}" ./cmd/reminal
 
 echo "Built ${OUTPUT}"
 "${OUTPUT}" version


### PR DESCRIPTION
## Summary

- centralize the built-in relay and web UI defaults in `internal/config`
- allow local builds to override those defaults through `REMINAL_DEFAULT_RELAY` and `REMINAL_DEFAULT_WEB`
- load optional overrides from a gitignored `reminal.build.env` in `scripts/build.sh`
- pass repository-level defaults through the release workflow so forks can publish binaries that point at their own relay
- document local relay development and Cloudflare deployment without requiring source edits

## Why

Fork maintainers currently need to edit tracked source files to make their binaries and hosted UI use a custom relay. That makes local testing noisy and makes upstream contributions harder to keep clean.

This change separates build-time defaults from runtime overrides. Forks can configure their own deployment, while contributors can build and test locally without modifying tracked files.

## Compatibility

The official upstream relay and web UI remain the fallback defaults. Builds that do not define any new variables behave exactly as before, including upstream release builds.

The existing runtime variables `REMINAL_RELAY`, `REMINAL_WEB`, and `REMINAL_LOCAL` continue to take precedence.

## Testing

- `go test ./...`
- added coverage for default URL derivation, build-time overrides, runtime overrides, and local mode

## Merge order

This PR is independent and can be merged in any order. If another viewer-related PR lands first, this branch may only need a conflict-only rebase because multiple PRs update the embedded and Cloudflare-hosted HTML copies. The branch should be retested after that rebase.