### PR TITLE
Show application icons in Windows and Apps lists

### DIFF
--- a/cloudflare/public/index.html
+++ b/cloudflare/public/index.html
@@ -748,6 +748,14 @@
       color: #58a6ff;
     }
     .recents-row .label { flex: 1; min-width: 0; }
+    .app-list-icon {
+      width: 24px; height: 24px; flex: 0 0 24px; display: grid; place-items: center;
+      border-radius: 7px; object-fit: contain; user-select: none;
+    }
+    .app-list-icon.fallback {
+      background: linear-gradient(145deg, #30363d, #161b22); border: 1px solid #3d444d;
+      color: #c9d1d9; font-size: 12px; font-weight: 700; box-sizing: border-box;
+    }
     /* The label is a real <a href="?s=…"> so ⌘-click / middle-click / "Open link
        in new tab" work natively; stretched back over the row's own padding so
        the whole body of the row is the link, not just the two lines of text. */
@@ -7331,6 +7339,7 @@
         const row = document.createElement('div');
         row.className = 'recents-row';
         row.title = 'Open and control this window';
+        row.appendChild(appListIcon(w));
         const label = document.createElement('div');
         label.className = 'label';
         const nameEl = document.createElement('div');
@@ -7403,6 +7412,7 @@
           const row = document.createElement('div');
           row.className = 'recents-row';
           row.title = 'Launch on the host';
+          row.appendChild(appListIcon(a));
           const label = document.createElement('div'); label.className = 'label';
           const nameEl = document.createElement('div'); nameEl.className = 'name';
           nameEl.textContent = a.name || 'App';
@@ -7415,6 +7425,20 @@
       search.addEventListener('input', draw);
       draw();
       setTimeout(() => search.focus(), 0);
+    }
+
+    function appListIcon(item) {
+      if (item && item.icon) {
+        const img = document.createElement('img');
+        img.className = 'app-list-icon'; img.src = item.icon; img.alt = '';
+        img.draggable = false;
+        return img;
+      }
+      const fallback = document.createElement('span');
+      fallback.className = 'app-list-icon fallback';
+      const name = (item && (item.name || item.app)) || '?';
+      fallback.textContent = Array.from(name.trim())[0] || '?';
+      return fallback;
     }
 
     // nextWindowList resolves with the window list from the next window_list

--- a/internal/client/web/index.html
+++ b/internal/client/web/index.html
@@ -748,6 +748,14 @@
       color: #58a6ff;
     }
     .recents-row .label { flex: 1; min-width: 0; }
+    .app-list-icon {
+      width: 24px; height: 24px; flex: 0 0 24px; display: grid; place-items: center;
+      border-radius: 7px; object-fit: contain; user-select: none;
+    }
+    .app-list-icon.fallback {
+      background: linear-gradient(145deg, #30363d, #161b22); border: 1px solid #3d444d;
+      color: #c9d1d9; font-size: 12px; font-weight: 700; box-sizing: border-box;
+    }
     /* The label is a real <a href="?s=…"> so ⌘-click / middle-click / "Open link
        in new tab" work natively; stretched back over the row's own padding so
        the whole body of the row is the link, not just the two lines of text. */
@@ -7331,6 +7339,7 @@
         const row = document.createElement('div');
         row.className = 'recents-row';
         row.title = 'Open and control this window';
+        row.appendChild(appListIcon(w));
         const label = document.createElement('div');
         label.className = 'label';
         const nameEl = document.createElement('div');
@@ -7403,6 +7412,7 @@
           const row = document.createElement('div');
           row.className = 'recents-row';
           row.title = 'Launch on the host';
+          row.appendChild(appListIcon(a));
           const label = document.createElement('div'); label.className = 'label';
           const nameEl = document.createElement('div'); nameEl.className = 'name';
           nameEl.textContent = a.name || 'App';
@@ -7415,6 +7425,20 @@
       search.addEventListener('input', draw);
       draw();
       setTimeout(() => search.focus(), 0);
+    }
+
+    function appListIcon(item) {
+      if (item && item.icon) {
+        const img = document.createElement('img');
+        img.className = 'app-list-icon'; img.src = item.icon; img.alt = '';
+        img.draggable = false;
+        return img;
+      }
+      const fallback = document.createElement('span');
+      fallback.className = 'app-list-icon fallback';
+      const name = (item && (item.name || item.app)) || '?';
+      fallback.textContent = Array.from(name.trim())[0] || '?';
+      return fallback;
     }
 
     // nextWindowList resolves with the window list from the next window_list

--- a/internal/client/windows.go
+++ b/internal/client/windows.go
@@ -44,6 +44,7 @@ type winInfo struct {
 	ID    string `json:"id"`
 	App   string `json:"app"`
 	Title string `json:"title"`
+	Icon  string `json:"icon,omitempty"`
 	X     int    `json:"x"`
 	Y     int    `json:"y"`
 	W     int    `json:"w"`
@@ -51,6 +52,10 @@ type winInfo struct {
 	// PID is the owning process id (macOS), used to activate the app reliably
 	// via NSRunningApplication. Not sent to the viewer.
 	PID int `json:"-"`
+	// AppPath identifies the owning application bundle when the backend can
+	// provide it. It is used only to look up the app icon and never leaves the
+	// host (the opaque window ID remains the viewer-facing handle).
+	AppPath string `json:"-"`
 	// CropL/CropT are the left/top invisible CSD shadow margins to crop off the
 	// captured image (Linux). X/Y/W/H already describe the content rect inside
 	// that shadow, so cropping by these offsets yields a borderless frame whose
@@ -135,6 +140,7 @@ type windowBackend interface {
 type appInfo struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
+	Icon string `json:"icon,omitempty"`
 }
 
 // newWindowBackend picks the backend for the current OS. Unknown platforms get

--- a/internal/client/windows_backends.go
+++ b/internal/client/windows_backends.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 // This file holds the concrete windowBackend implementations. They only shell
@@ -58,7 +59,8 @@ func (darwinWindows) permissionHint() string {
 // each window — which lets screencapture grab the window by id even when it's
 // occluded, and requires no Accessibility permission (only Screen Recording,
 // which capture needs anyway). Emits tab-separated
-// "id<TAB>owner<TAB>title<TAB>x<TAB>y<TAB>w<TAB>h" lines. Layer 0 filters to
+// "id<TAB>pid<TAB>bundle<TAB>owner<TAB>title<TAB>x<TAB>y<TAB>w<TAB>h" lines.
+// Layer 0 filters to
 // normal application windows (skips the menu bar, Dock, shadows, etc.).
 const jxaListScript = `ObjC.import("CoreGraphics"); ObjC.import("Foundation"); ObjC.import("AppKit");
 var arr = ObjC.castRefToObject($.CGWindowListCopyWindowInfo($.kCGWindowListOptionOnScreenOnly | $.kCGWindowListExcludeDesktopElements, $.kCGNullWindowID));
@@ -70,8 +72,10 @@ for (var i = 0; i < n; i++) {
   var name = w.objectForKey("kCGWindowName");
   var num = w.objectForKey("kCGWindowNumber").intValue;
   var pid = w.objectForKey("kCGWindowOwnerPID").intValue;
+  var running = $.NSRunningApplication.runningApplicationWithProcessIdentifier(pid);
+  var bundle = running && running.bundleURL ? ObjC.unwrap(running.bundleURL.path) : "";
   var b = w.objectForKey("kCGWindowBounds");
-  out.push([num, pid, owner ? ObjC.unwrap(owner) : "", name ? ObjC.unwrap(name) : "",
+  out.push([num, pid, bundle, owner ? ObjC.unwrap(owner) : "", name ? ObjC.unwrap(name) : "",
     b.objectForKey("X").intValue, b.objectForKey("Y").intValue,
     b.objectForKey("Width").intValue, b.objectForKey("Height").intValue].join("\t"));
 }
@@ -84,7 +88,7 @@ for (var i = 0; i < screens.count; i++) {
   var db = $.CGDisplayBounds(did);
   var dw = Math.round(db.size.width), dh = Math.round(db.size.height);
   var label = (screens.count > 1 ? "Display " + (i + 1) : "Entire screen") + " — " + dw + "×" + dh;
-  out.push(["display:" + did, 0, "Desktop", label,
+  out.push(["display:" + did, 0, "", "Desktop", label,
     Math.round(db.origin.x), Math.round(db.origin.y), dw, dh].join("\t"));
 }
 out.join("\n");`
@@ -104,21 +108,103 @@ func (darwinWindows) list() ([]winInfo, error) {
 			continue
 		}
 		f := strings.Split(line, "\t")
-		if len(f) < 8 {
+		if len(f) < 9 {
 			continue
 		}
 		// Title may itself contain tabs; the numeric fields are the last four.
 		n := len(f)
-		id, pid, owner := f[0], atoi(f[1]), f[2]
-		title := strings.Join(f[3:n-4], "\t")
+		id, pid, appPath, owner := f[0], atoi(f[1]), f[2], f[3]
+		title := strings.Join(f[4:n-4], "\t")
 		x, y := atoi(f[n-4]), atoi(f[n-3])
 		w, h := atoi(f[n-2]), atoi(f[n-1])
 		if w < 40 || h < 40 {
 			continue
 		}
-		wins = append(wins, winInfo{ID: id, PID: pid, App: owner, Title: title, X: x, Y: y, W: w, H: h})
+		wins = append(wins, winInfo{ID: id, PID: pid, AppPath: appPath, App: owner, Title: title, X: x, Y: y, W: w, H: h})
 	}
+	darwinAddWindowIcons(wins)
 	return wins, nil
+}
+
+// macOS exposes the canonical icon for any application bundle through
+// NSWorkspace. Render it into a small Retina-aware bitmap in one JXA process
+// for the whole batch: spawning osascript once per app makes opening the Apps
+// menu needlessly slow. The resulting PNG data URLs can be rendered directly
+// by the browser and stay end-to-end encrypted with the rest of the list.
+const jxaAppIconsScript = `ObjC.import("AppKit");
+function run(argv) {
+  // AppKit renders this point size at 2× on Retina hosts, yielding a crisp
+  // 24px bitmap for the browser without bloating the encrypted app list.
+  var out = [], n = 12;
+  for (var i = 0; i < argv.length; i++) {
+    try {
+      var path = String(argv[i]);
+      var src = $.NSWorkspace.sharedWorkspace.iconForFile(path);
+      if (!src) continue;
+      var dst = $.NSImage.alloc.initWithSize($.NSMakeSize(n, n));
+      dst.lockFocus;
+      src.drawInRectFromRectOperationFraction($.NSMakeRect(0, 0, n, n), $.NSZeroRect,
+        $.NSCompositingOperationCopy, 1);
+      dst.unlockFocus;
+      var rep = $.NSBitmapImageRep.imageRepWithData(dst.TIFFRepresentation);
+      var png = rep.representationUsingTypeProperties($.NSBitmapImageFileTypePNG, $({}));
+      out.push(path + "\t" + ObjC.unwrap(png.base64EncodedStringWithOptions(0)));
+    } catch (_) {}
+  }
+  return out.join("\n");
+}`
+
+var darwinIconCache sync.Map // bundle path -> data URL (empty string caches failures)
+
+func darwinIcons(paths []string) map[string]string {
+	icons := make(map[string]string, len(paths))
+	missing := make([]string, 0, len(paths))
+	seen := make(map[string]bool, len(paths))
+	for _, path := range paths {
+		if path == "" || seen[path] {
+			continue
+		}
+		seen[path] = true
+		if cached, ok := darwinIconCache.Load(path); ok {
+			if icon, _ := cached.(string); icon != "" {
+				icons[path] = icon
+			}
+			continue
+		}
+		missing = append(missing, path)
+	}
+	if len(missing) != 0 {
+		args := append([]string{"-l", "JavaScript", "-e", jxaAppIconsScript, "--"}, missing...)
+		out, err := run("osascript", args...)
+		found := make(map[string]string, len(missing))
+		if err == nil {
+			for _, line := range strings.Split(out, "\n") {
+				f := strings.SplitN(line, "\t", 2)
+				if len(f) == 2 && f[0] != "" && f[1] != "" {
+					found[f[0]] = "data:image/png;base64," + f[1]
+				}
+			}
+		}
+		for _, path := range missing {
+			icon := found[path]
+			darwinIconCache.Store(path, icon)
+			if icon != "" {
+				icons[path] = icon
+			}
+		}
+	}
+	return icons
+}
+
+func darwinAddWindowIcons(wins []winInfo) {
+	paths := make([]string, 0, len(wins))
+	for i := range wins {
+		paths = append(paths, wins[i].AppPath)
+	}
+	icons := darwinIcons(paths)
+	for i := range wins {
+		wins[i].Icon = icons[wins[i].AppPath]
+	}
 }
 
 // winMaxWidth is the width we downscale captured frames to. Retina windows
@@ -225,6 +311,25 @@ func (darwinWindows) listApps() ([]appInfo, error) {
 	sort.Slice(apps, func(i, j int) bool {
 		return strings.ToLower(apps[i].Name) < strings.ToLower(apps[j].Name)
 	})
+	paths := make([]string, len(apps))
+	for i := range apps {
+		paths[i] = apps[i].ID
+	}
+	icons := darwinIcons(paths)
+	// Keep comfortable headroom below the relay's 1 MiB encrypted-frame cap.
+	// Encryption base64-expands the JSON again, so cap the already-base64 icon
+	// strings at 560 KiB. Extremely large app collections retain names and use
+	// the browser's fallback tile after this budget is exhausted.
+	const iconBudget = 600 << 10
+	used := 0
+	for i := range apps {
+		icon := icons[apps[i].ID]
+		if icon == "" || used+len(icon) > iconBudget {
+			continue
+		}
+		apps[i].Icon = icon
+		used += len(icon)
+	}
 	return apps, nil
 }
 

--- a/internal/protocol/messages.go
+++ b/internal/protocol/messages.go
@@ -150,7 +150,9 @@ const (
 
 	// TypeWindowList is bidirectional. Viewer→agent: a request with empty
 	// Data ("what windows are open?"). Agent→viewer: the reply, Data =
-	// encrypted JSON {"windows":[{"id","app","title","x","y","w","h"}, ...]}.
+	// encrypted JSON
+	// {"windows":[{"id","app","title","icon","x","y","w","h"}, ...]}.
+	// icon is an optional PNG data URL supplied by backends that can resolve it.
 	TypeWindowList MessageType = "window_list"
 
 	// TypeWindowNotes carries the agent→viewer note list for annotated windows —
@@ -188,7 +190,8 @@ const (
 
 	// TypeAppList is bidirectional. Viewer→agent: an empty-Data request ("what
 	// apps can I launch?"). Agent→viewer: the reply, Data = encrypted JSON
-	// {"apps":[{"id","name"}, ...]} of installed apps, or {"unsupported":"..."}.
+	// {"apps":[{"id","name","icon"}, ...]} of installed apps, or
+	// {"unsupported":"..."}. icon is optional for backend compatibility.
 	TypeAppList MessageType = "app_list"
 	// TypeAppOpen is viewer→agent. Data = encrypted JSON {"id":"<app id>"} —
 	// launch (or foreground) that app so its window shows up in the window list.


### PR DESCRIPTION

<img width="1266" height="1484" alt="Apps_list_logo_preview" src="https://github.com/user-attachments/assets/989c6bbe-4d4e-453b-8157-70bc390921be" />

## Summary

- include an optional application icon in window and app-list protocol payloads
- resolve native macOS application icons from bundle paths through AppKit
- cache icon lookups to avoid repeatedly decoding the same bundle icon
- apply a payload budget when attaching icons to the app list
- render icons in both the Windows and Apps pickers, with an initial-letter fallback when no icon is available
- keep the embedded viewer and Cloudflare-hosted viewer in sync

## Why

Window and application lists are difficult to scan when several entries have similar names or titles. Native icons provide a much faster visual cue, especially in long application lists.

The fields are optional, so other platforms and older agents/viewers continue to work without icons.

## Implementation notes

On macOS, the backend now retains the owning application bundle path while enumerating windows. AppKit renders each icon as a compact PNG data URL. Bundle paths remain host-local and are never sent to the viewer.

Icon failures are cached, and the app-list response has a total icon budget to prevent large encrypted control messages.

## Testing

- `go test ./internal/client ./internal/protocol`
- verified the embedded and Cloudflare viewer HTML files are byte-identical

## Merge order

This PR is independent and can be merged in any order. If another viewer-related PR lands first, this branch may only need a conflict-only rebase because multiple PRs update the embedded and Cloudflare-hosted HTML copies. The branch should be retested after that rebase.