### PR TITLE
Adapt window capture quality to pane size and transport

### DIFF
--- a/cloudflare/public/index.html
+++ b/cloudflare/public/index.html
@@ -7007,12 +7007,18 @@
     // always re-stamps itself first).
     const TRANSPORT_CLAIM_MS = 5000;
     function noteTransport(viaDC) {
-      if (viaDC) { lastDCSeenAt = performance.now(); lastFrameVia = 'webrtc'; return; }
+      const before = lastFrameVia;
+      if (viaDC) {
+        lastDCSeenAt = performance.now(); lastFrameVia = 'webrtc';
+        if (before !== lastFrameVia) for (const p of panes.values()) requestPaneQuality(p);
+        return;
+      }
       // !lastDCSeenAt = no DataChannel traffic EVER — claim immediately. (The
       // 0 init otherwise reads as "DC activity at page load", which blocked
       // relay frames from labeling for the page's first 5s: the popover sat on
       // "—" while frames were already painting.)
       if (!lastDCSeenAt || performance.now() - lastDCSeenAt > TRANSPORT_CLAIM_MS) lastFrameVia = 'ws';
+      if (before !== lastFrameVia) for (const p of panes.values()) requestPaneQuality(p);
     }
     // Describe the current transport for a pane's (i) popover.
     function paneInfoHtml(p) {
@@ -7023,7 +7029,10 @@
       else if (lastFrameVia === 'ws') { transport = 'Relay · WebSocket'; cls = 'ws'; }
       else { transport = '—'; cls = ''; }
       const enc = webrtc ? 'DTLS (end-to-end)' : 'AES-256-GCM (end-to-end)';
-      const res = (p.w.w && p.w.h) ? (p.w.w + '×' + p.w.h) : '—';
+      // Canvas intrinsic pixels are the stream's real capture resolution. The
+      // old value was the host window's logical-point size, so the info panel
+      // could claim a resolution unrelated to the pixels being decoded.
+      const res = (p.gotFrame && p.img.width && p.img.height) ? (p.img.width + '×' + p.img.height) : '—';
       // Prune on READ. The rolling window is otherwise only trimmed when a
       // frame ARRIVES, so a stream that stopped kept reporting whatever rate
       // it last had — a frozen pane showing a healthy fps, which is the single
@@ -7587,7 +7596,7 @@
       infoEl.addEventListener('pointerdown', (e) => e.stopPropagation()); // don't drag/focus when interacting
 
       focusPane(w.id);
-      sendWin('window_ctl', { action: 'start', id: w.id, viewer: viewerId });
+      sendPaneStart(pane);
       announcePaneInterest();
       savePaneLayout();
     }
@@ -7730,7 +7739,7 @@
       winStreamsPaused = false;
       for (const [id, p] of panes) {
         resetPaneStreamCursors(p);
-        sendWin('window_ctl', { action: 'start', id, viewer: viewerId });
+        sendPaneStart(p);
       }
     }
     function resumeWinStreams() {
@@ -8089,7 +8098,7 @@
         if (p.gotFrame && staleFor > 9000 && (!p.reqAt || performance.now() - p.reqAt > 10000)) {
           p.reqAt = performance.now();
           resetPaneStreamCursors(p);
-          sendWin('window_ctl', { action: 'start', id: p.w.id, viewer: viewerId });
+          sendPaneStart(p);
         }
         // Safety net for playout: if frames are queued and overdue, rAF is not
         // running (every window holding this pane is hidden, or the browser
@@ -8625,6 +8634,71 @@
       bar.addEventListener('pointercancel', end);
     }
 
+    // Match capture pixels to what the browser can actually display. Network
+    // Information is only a hint (and absent in Safari), so transport and pane
+    // size remain the primary signals. Requests are host-clamped and debounced.
+    function paneQualityProfile(pane) {
+      const conn = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+      const effective = conn && conn.effectiveType || '';
+      const save = !!(conn && conn.saveData);
+      const downlink = conn && Number(conn.downlink) || 0;
+      const rtt = conn && Number(conn.rtt) || 0;
+      const fr = frameRect(pane.img.getBoundingClientRect(), pane.img.width, pane.img.height);
+      const displayPx = Math.ceil(Math.max(1, fr.width) * Math.max(1, window.devicePixelRatio || 1));
+      let maxWidth = Math.max(1100, Math.min(2880, displayPx));
+      let quality = 68;
+      // A confirmed direct WebRTC path does not traverse the relay and its
+      // observed throughput is more trustworthy than Network Information's
+      // coarse, often stale internet estimate. Preserve only an explicit
+      // Save-Data request; otherwise use the full native-detail profile so a
+      // Retina source remains sharp when the pane is enlarged or pinch-zoomed.
+      if (lastFrameVia === 'webrtc' && !save) { maxWidth = 2880; quality = 80; }
+      else if (save || effective === 'slow-2g' || effective === '2g' || (downlink > 0 && downlink < 1.5)) { maxWidth = 800; quality = 40; }
+      else if (effective === '3g' || (downlink > 0 && downlink < 4) || rtt > 300) { maxWidth = Math.min(maxWidth, 1100); quality = 48; }
+      // A relay route is not evidence of a slow network — NAT can prevent P2P
+      // on an otherwise excellent link. This deployment is user-owned, so let
+      // a good relay connection use the high-detail tier too.
+      else if (lastFrameVia !== 'webrtc') { maxWidth = Math.min(maxWidth, 2560); quality = 74; }
+      else if (maxWidth >= 2400) quality = 80;
+      else if (maxWidth >= 1600) quality = 72;
+      // Stable buckets prevent a one-pixel resize from restarting capture.
+      maxWidth = maxWidth <= 800 ? 800 : maxWidth <= 1100 ? 1100 : maxWidth <= 1440 ? 1440 : maxWidth <= 1920 ? 1920 : maxWidth <= 2560 ? 2560 : 2880;
+      return { max_width: maxWidth, quality };
+    }
+    function requestPaneQuality(pane, immediate) {
+      if (!pane) return;
+      const apply = () => {
+        pane.qualityTimer = null;
+        const q = paneQualityProfile(pane);
+        const key = q.max_width + ':' + q.quality;
+        if (pane.qualityKey === key) return;
+        pane.qualityKey = key;
+        sendWin('window_ctl', { action: 'quality', id: pane.w.id, viewer: viewerId, ...q });
+      };
+      if (immediate) {
+        if (pane.qualityTimer) clearTimeout(pane.qualityTimer);
+        apply();
+      } else if (!pane.qualityTimer) {
+        // Throttle (rather than debounce) resize negotiation. During a long
+        // drag this applies the newest size every 150ms, while qualityKey means
+        // only actual 800/1100/1440/1920/2560/2880 tier crossings reach the
+        // Agent and restart its capture pipeline.
+        pane.qualityTimer = setTimeout(apply, 150);
+      }
+    }
+    function sendPaneStart(pane) {
+      const q = paneQualityProfile(pane);
+      pane.qualityKey = q.max_width + ':' + q.quality;
+      sendWin('window_ctl', { action: 'start', id: pane.w.id, viewer: viewerId, ...q });
+    }
+    const netInfo = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+    if (netInfo && netInfo.addEventListener) netInfo.addEventListener('change', () => {
+      for (const p of panes.values()) requestPaneQuality(p);
+    });
+    window.addEventListener('resize', () => {
+      for (const p of panes.values()) requestPaneQuality(p);
+    });
+
     // Resize from the bottom-right handle; width drives height via image aspect.
     function paneResize(pane, rz) {
       let s = null;
@@ -8638,8 +8712,9 @@
         if (!s) return;
         pane.el.style.width = Math.max(160, s.w + e.clientX - s.px) + 'px';
         if (pane.placeCursor) pane.placeCursor();
+        requestPaneQuality(pane);
       });
-      const end = () => { if (s) { s = null; savePaneLayout(); } };
+      const end = () => { if (s) { s = null; savePaneLayout(); requestPaneQuality(pane, true); } };
       rz.addEventListener('pointerup', end);
       rz.addEventListener('pointercancel', end);
     }
@@ -8885,6 +8960,10 @@
               click(pane.cursor || fracAt(pinch.mx, pinch.my), 'right'); flash();
             }
             pinch = null; clampPan(); applyTransform();
+            // getBoundingClientRect now reflects the zoomed display size.
+            // Re-evaluate capture pixels so zooming does not merely magnify
+            // the old low-resolution source frame.
+            requestPaneQuality(pane);
           }
           downAt = 0; return;
         }

--- a/cloudflare/public/index.html
+++ b/cloudflare/public/index.html
@@ -7033,6 +7033,7 @@
       // old value was the host window's logical-point size, so the info panel
       // could claim a resolution unrelated to the pixels being decoded.
       const res = (p.gotFrame && p.img.width && p.img.height) ? (p.img.width + '×' + p.img.height) : '—';
+      const profile = p.qualityKey ? p.qualityKey.replace(':', '@') : '—';
       // Prune on READ. The rolling window is otherwise only trimmed when a
       // frame ARRIVES, so a stream that stopped kept reporting whatever rate
       // it last had — a frozen pane showing a healthy fps, which is the single
@@ -7069,6 +7070,7 @@
         + health
         + '<div class="row"><span class="k">Encryption</span><span class="v">' + enc + '</span></div>'
         + '<div class="row"><span class="k">Resolution</span><span class="v">' + res + '</span></div>'
+        + '<div class="row"><span class="k">Requested</span><span class="v">' + profile + '</span></div>'
         + '<div class="row"><span class="k">Frame rate</span><span class="v">' + rate + '</span></div>';
     }
 
@@ -8647,12 +8649,14 @@
       const displayPx = Math.ceil(Math.max(1, fr.width) * Math.max(1, window.devicePixelRatio || 1));
       let maxWidth = Math.max(1100, Math.min(2880, displayPx));
       let quality = 68;
-      // A confirmed direct WebRTC path does not traverse the relay and its
-      // observed throughput is more trustworthy than Network Information's
-      // coarse, often stale internet estimate. Preserve only an explicit
-      // Save-Data request; otherwise use the full native-detail profile so a
-      // Retina source remains sharp when the pane is enlarged or pinch-zoomed.
-      if (lastFrameVia === 'webrtc' && !save) { maxWidth = 2880; quality = 80; }
+      // A confirmed direct WebRTC path can use a higher quality ceiling, but
+      // pane size still chooses the resolution tier. A small pane should not
+      // restart capture at 2880 merely because its route is peer-to-peer.
+      // Live connection stats can move this tier later; Network Information
+      // remains only a coarse fallback and Save-Data stays authoritative.
+      if (lastFrameVia === 'webrtc' && !save) {
+        quality = maxWidth >= 2400 ? 80 : maxWidth >= 1600 ? 76 : 72;
+      }
       else if (save || effective === 'slow-2g' || effective === '2g' || (downlink > 0 && downlink < 1.5)) { maxWidth = 800; quality = 40; }
       else if (effective === '3g' || (downlink > 0 && downlink < 4) || rtt > 300) { maxWidth = Math.min(maxWidth, 1100); quality = 48; }
       // A relay route is not evidence of a slow network — NAT can prevent P2P
@@ -8673,6 +8677,7 @@
         const key = q.max_width + ':' + q.quality;
         if (pane.qualityKey === key) return;
         pane.qualityKey = key;
+        if (pane.infoShown) pane.infoEl.innerHTML = paneInfoHtml(pane);
         sendWin('window_ctl', { action: 'quality', id: pane.w.id, viewer: viewerId, ...q });
       };
       if (immediate) {

--- a/internal/client/agent.go
+++ b/internal/client/agent.go
@@ -309,6 +309,11 @@ type Agent struct {
 	// are delivered on, so streamWindow can pace to the viewer (see streamWindow).
 	// Guarded by winMu.
 	winAck map[string]chan uint64
+	// winQuality carries browser-requested capture profiles to live streams.
+	// The request is derived from the pane's rendered pixel size and the
+	// browser's current network hint, so a large pane on a good link can be
+	// sharp without forcing that cost on every viewer. Guarded by winMu.
+	winQuality map[string]chan windowQuality
 	// winKeyReq maps a streaming window's id to a flag a viewer raises when it
 	// detects a gap in the H.264 frame sequence and needs a fresh keyframe to
 	// resync. A flag rather than a channel: many gapped frames coalesce into

--- a/internal/client/web/index.html
+++ b/internal/client/web/index.html
@@ -7007,12 +7007,18 @@
     // always re-stamps itself first).
     const TRANSPORT_CLAIM_MS = 5000;
     function noteTransport(viaDC) {
-      if (viaDC) { lastDCSeenAt = performance.now(); lastFrameVia = 'webrtc'; return; }
+      const before = lastFrameVia;
+      if (viaDC) {
+        lastDCSeenAt = performance.now(); lastFrameVia = 'webrtc';
+        if (before !== lastFrameVia) for (const p of panes.values()) requestPaneQuality(p);
+        return;
+      }
       // !lastDCSeenAt = no DataChannel traffic EVER — claim immediately. (The
       // 0 init otherwise reads as "DC activity at page load", which blocked
       // relay frames from labeling for the page's first 5s: the popover sat on
       // "—" while frames were already painting.)
       if (!lastDCSeenAt || performance.now() - lastDCSeenAt > TRANSPORT_CLAIM_MS) lastFrameVia = 'ws';
+      if (before !== lastFrameVia) for (const p of panes.values()) requestPaneQuality(p);
     }
     // Describe the current transport for a pane's (i) popover.
     function paneInfoHtml(p) {
@@ -7023,7 +7029,10 @@
       else if (lastFrameVia === 'ws') { transport = 'Relay · WebSocket'; cls = 'ws'; }
       else { transport = '—'; cls = ''; }
       const enc = webrtc ? 'DTLS (end-to-end)' : 'AES-256-GCM (end-to-end)';
-      const res = (p.w.w && p.w.h) ? (p.w.w + '×' + p.w.h) : '—';
+      // Canvas intrinsic pixels are the stream's real capture resolution. The
+      // old value was the host window's logical-point size, so the info panel
+      // could claim a resolution unrelated to the pixels being decoded.
+      const res = (p.gotFrame && p.img.width && p.img.height) ? (p.img.width + '×' + p.img.height) : '—';
       // Prune on READ. The rolling window is otherwise only trimmed when a
       // frame ARRIVES, so a stream that stopped kept reporting whatever rate
       // it last had — a frozen pane showing a healthy fps, which is the single
@@ -7587,7 +7596,7 @@
       infoEl.addEventListener('pointerdown', (e) => e.stopPropagation()); // don't drag/focus when interacting
 
       focusPane(w.id);
-      sendWin('window_ctl', { action: 'start', id: w.id, viewer: viewerId });
+      sendPaneStart(pane);
       announcePaneInterest();
       savePaneLayout();
     }
@@ -7730,7 +7739,7 @@
       winStreamsPaused = false;
       for (const [id, p] of panes) {
         resetPaneStreamCursors(p);
-        sendWin('window_ctl', { action: 'start', id, viewer: viewerId });
+        sendPaneStart(p);
       }
     }
     function resumeWinStreams() {
@@ -8089,7 +8098,7 @@
         if (p.gotFrame && staleFor > 9000 && (!p.reqAt || performance.now() - p.reqAt > 10000)) {
           p.reqAt = performance.now();
           resetPaneStreamCursors(p);
-          sendWin('window_ctl', { action: 'start', id: p.w.id, viewer: viewerId });
+          sendPaneStart(p);
         }
         // Safety net for playout: if frames are queued and overdue, rAF is not
         // running (every window holding this pane is hidden, or the browser
@@ -8625,6 +8634,71 @@
       bar.addEventListener('pointercancel', end);
     }
 
+    // Match capture pixels to what the browser can actually display. Network
+    // Information is only a hint (and absent in Safari), so transport and pane
+    // size remain the primary signals. Requests are host-clamped and debounced.
+    function paneQualityProfile(pane) {
+      const conn = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+      const effective = conn && conn.effectiveType || '';
+      const save = !!(conn && conn.saveData);
+      const downlink = conn && Number(conn.downlink) || 0;
+      const rtt = conn && Number(conn.rtt) || 0;
+      const fr = frameRect(pane.img.getBoundingClientRect(), pane.img.width, pane.img.height);
+      const displayPx = Math.ceil(Math.max(1, fr.width) * Math.max(1, window.devicePixelRatio || 1));
+      let maxWidth = Math.max(1100, Math.min(2880, displayPx));
+      let quality = 68;
+      // A confirmed direct WebRTC path does not traverse the relay and its
+      // observed throughput is more trustworthy than Network Information's
+      // coarse, often stale internet estimate. Preserve only an explicit
+      // Save-Data request; otherwise use the full native-detail profile so a
+      // Retina source remains sharp when the pane is enlarged or pinch-zoomed.
+      if (lastFrameVia === 'webrtc' && !save) { maxWidth = 2880; quality = 80; }
+      else if (save || effective === 'slow-2g' || effective === '2g' || (downlink > 0 && downlink < 1.5)) { maxWidth = 800; quality = 40; }
+      else if (effective === '3g' || (downlink > 0 && downlink < 4) || rtt > 300) { maxWidth = Math.min(maxWidth, 1100); quality = 48; }
+      // A relay route is not evidence of a slow network — NAT can prevent P2P
+      // on an otherwise excellent link. This deployment is user-owned, so let
+      // a good relay connection use the high-detail tier too.
+      else if (lastFrameVia !== 'webrtc') { maxWidth = Math.min(maxWidth, 2560); quality = 74; }
+      else if (maxWidth >= 2400) quality = 80;
+      else if (maxWidth >= 1600) quality = 72;
+      // Stable buckets prevent a one-pixel resize from restarting capture.
+      maxWidth = maxWidth <= 800 ? 800 : maxWidth <= 1100 ? 1100 : maxWidth <= 1440 ? 1440 : maxWidth <= 1920 ? 1920 : maxWidth <= 2560 ? 2560 : 2880;
+      return { max_width: maxWidth, quality };
+    }
+    function requestPaneQuality(pane, immediate) {
+      if (!pane) return;
+      const apply = () => {
+        pane.qualityTimer = null;
+        const q = paneQualityProfile(pane);
+        const key = q.max_width + ':' + q.quality;
+        if (pane.qualityKey === key) return;
+        pane.qualityKey = key;
+        sendWin('window_ctl', { action: 'quality', id: pane.w.id, viewer: viewerId, ...q });
+      };
+      if (immediate) {
+        if (pane.qualityTimer) clearTimeout(pane.qualityTimer);
+        apply();
+      } else if (!pane.qualityTimer) {
+        // Throttle (rather than debounce) resize negotiation. During a long
+        // drag this applies the newest size every 150ms, while qualityKey means
+        // only actual 800/1100/1440/1920/2560/2880 tier crossings reach the
+        // Agent and restart its capture pipeline.
+        pane.qualityTimer = setTimeout(apply, 150);
+      }
+    }
+    function sendPaneStart(pane) {
+      const q = paneQualityProfile(pane);
+      pane.qualityKey = q.max_width + ':' + q.quality;
+      sendWin('window_ctl', { action: 'start', id: pane.w.id, viewer: viewerId, ...q });
+    }
+    const netInfo = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+    if (netInfo && netInfo.addEventListener) netInfo.addEventListener('change', () => {
+      for (const p of panes.values()) requestPaneQuality(p);
+    });
+    window.addEventListener('resize', () => {
+      for (const p of panes.values()) requestPaneQuality(p);
+    });
+
     // Resize from the bottom-right handle; width drives height via image aspect.
     function paneResize(pane, rz) {
       let s = null;
@@ -8638,8 +8712,9 @@
         if (!s) return;
         pane.el.style.width = Math.max(160, s.w + e.clientX - s.px) + 'px';
         if (pane.placeCursor) pane.placeCursor();
+        requestPaneQuality(pane);
       });
-      const end = () => { if (s) { s = null; savePaneLayout(); } };
+      const end = () => { if (s) { s = null; savePaneLayout(); requestPaneQuality(pane, true); } };
       rz.addEventListener('pointerup', end);
       rz.addEventListener('pointercancel', end);
     }
@@ -8885,6 +8960,10 @@
               click(pane.cursor || fracAt(pinch.mx, pinch.my), 'right'); flash();
             }
             pinch = null; clampPan(); applyTransform();
+            // getBoundingClientRect now reflects the zoomed display size.
+            // Re-evaluate capture pixels so zooming does not merely magnify
+            // the old low-resolution source frame.
+            requestPaneQuality(pane);
           }
           downAt = 0; return;
         }

--- a/internal/client/web/index.html
+++ b/internal/client/web/index.html
@@ -7033,6 +7033,7 @@
       // old value was the host window's logical-point size, so the info panel
       // could claim a resolution unrelated to the pixels being decoded.
       const res = (p.gotFrame && p.img.width && p.img.height) ? (p.img.width + '×' + p.img.height) : '—';
+      const profile = p.qualityKey ? p.qualityKey.replace(':', '@') : '—';
       // Prune on READ. The rolling window is otherwise only trimmed when a
       // frame ARRIVES, so a stream that stopped kept reporting whatever rate
       // it last had — a frozen pane showing a healthy fps, which is the single
@@ -7069,6 +7070,7 @@
         + health
         + '<div class="row"><span class="k">Encryption</span><span class="v">' + enc + '</span></div>'
         + '<div class="row"><span class="k">Resolution</span><span class="v">' + res + '</span></div>'
+        + '<div class="row"><span class="k">Requested</span><span class="v">' + profile + '</span></div>'
         + '<div class="row"><span class="k">Frame rate</span><span class="v">' + rate + '</span></div>';
     }
 
@@ -8647,12 +8649,14 @@
       const displayPx = Math.ceil(Math.max(1, fr.width) * Math.max(1, window.devicePixelRatio || 1));
       let maxWidth = Math.max(1100, Math.min(2880, displayPx));
       let quality = 68;
-      // A confirmed direct WebRTC path does not traverse the relay and its
-      // observed throughput is more trustworthy than Network Information's
-      // coarse, often stale internet estimate. Preserve only an explicit
-      // Save-Data request; otherwise use the full native-detail profile so a
-      // Retina source remains sharp when the pane is enlarged or pinch-zoomed.
-      if (lastFrameVia === 'webrtc' && !save) { maxWidth = 2880; quality = 80; }
+      // A confirmed direct WebRTC path can use a higher quality ceiling, but
+      // pane size still chooses the resolution tier. A small pane should not
+      // restart capture at 2880 merely because its route is peer-to-peer.
+      // Live connection stats can move this tier later; Network Information
+      // remains only a coarse fallback and Save-Data stays authoritative.
+      if (lastFrameVia === 'webrtc' && !save) {
+        quality = maxWidth >= 2400 ? 80 : maxWidth >= 1600 ? 76 : 72;
+      }
       else if (save || effective === 'slow-2g' || effective === '2g' || (downlink > 0 && downlink < 1.5)) { maxWidth = 800; quality = 40; }
       else if (effective === '3g' || (downlink > 0 && downlink < 4) || rtt > 300) { maxWidth = Math.min(maxWidth, 1100); quality = 48; }
       // A relay route is not evidence of a slow network — NAT can prevent P2P
@@ -8673,6 +8677,7 @@
         const key = q.max_width + ':' + q.quality;
         if (pane.qualityKey === key) return;
         pane.qualityKey = key;
+        if (pane.infoShown) pane.infoEl.innerHTML = paneInfoHtml(pane);
         sendWin('window_ctl', { action: 'quality', id: pane.w.id, viewer: viewerId, ...q });
       };
       if (immediate) {

--- a/internal/client/webrtc.go
+++ b/internal/client/webrtc.go
@@ -180,9 +180,9 @@ type rtcPeer struct {
 // Dropping instead is what a video call does — the viewer sees a sequence gap
 // and asks for a keyframe (submitAU → requestH264Key), which it already did for
 // packets lost in flight. Sized at roughly a quarter-second of the encoder's
-// 6 Mbps ceiling: deep enough to ride out a burst, shallow enough that the
+// 12 Mbps high-quality ceiling: deep enough to ride out a burst, shallow enough that the
 // picture stays current rather than replaying the past.
-const rtcSendBudget = 192 << 10
+const rtcSendBudget = 384 << 10
 
 // sendFrame hands one frame message to this peer, unless its send queue is
 // already over budget. Best effort by design: the viewer's gap detection is

--- a/internal/client/window_quality_test.go
+++ b/internal/client/window_quality_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package client
+
+import "testing"
+
+func TestWindowQualityNormalized(t *testing.T) {
+	tests := []struct {
+		name string
+		in   windowQuality
+		want windowQuality
+	}{
+		{"defaults", windowQuality{}, windowQuality{MaxWidth: winMaxWidth, Quality: winCaptureQuality}},
+		{"low bounds", windowQuality{MaxWidth: 100, Quality: 1}, windowQuality{MaxWidth: 720, Quality: 35}},
+		{"high bounds", windowQuality{MaxWidth: 9000, Quality: 100}, windowQuality{MaxWidth: 2880, Quality: 82}},
+		{"requested", windowQuality{MaxWidth: 1440, Quality: 64}, windowQuality{MaxWidth: 1440, Quality: 64}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.in.normalized(); got != tt.want {
+				t.Fatalf("normalized() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTuneWindowStreamKeepsNewestProfile(t *testing.T) {
+	ch := make(chan windowQuality, 1)
+	a := &Agent{winQuality: map[string]chan windowQuality{"w1": ch}}
+	a.tuneWindowStream("w1", windowQuality{MaxWidth: 1100, Quality: 48})
+	a.tuneWindowStream("w1", windowQuality{MaxWidth: 2880, Quality: 80})
+	if got := <-ch; got != (windowQuality{MaxWidth: 2880, Quality: 80}) {
+		t.Fatalf("queued profile = %+v, want newest", got)
+	}
+}
+
+func TestAutomaticWindowQualityUsesSharperRelayTier(t *testing.T) {
+	s := &winStream{a: &Agent{}, profile: (windowQuality{}).normalized()}
+	s.applyAutomaticQuality()
+	want := windowQuality{MaxWidth: 1920, Quality: 68}
+	if s.profile != want {
+		t.Fatalf("automatic relay profile = %+v, want %+v", s.profile, want)
+	}
+
+	// An explicit browser preference (for example Save-Data) must not be
+	// overwritten by the host's transport heuristic.
+	s.profile = windowQuality{MaxWidth: 800, Quality: 40}
+	s.profileExplicit = true
+	s.applyAutomaticQuality()
+	if s.profile != (windowQuality{MaxWidth: 800, Quality: 40}) {
+		t.Fatalf("automatic profile overwrote explicit request: %+v", s.profile)
+	}
+}

--- a/internal/client/window_quality_test.go
+++ b/internal/client/window_quality_test.go
@@ -34,20 +34,12 @@ func TestTuneWindowStreamKeepsNewestProfile(t *testing.T) {
 	}
 }
 
-func TestAutomaticWindowQualityUsesSharperRelayTier(t *testing.T) {
-	s := &winStream{a: &Agent{}, profile: (windowQuality{}).normalized()}
-	s.applyAutomaticQuality()
-	want := windowQuality{MaxWidth: 1920, Quality: 68}
-	if s.profile != want {
-		t.Fatalf("automatic relay profile = %+v, want %+v", s.profile, want)
-	}
-
-	// An explicit browser preference (for example Save-Data) must not be
-	// overwritten by the host's transport heuristic.
-	s.profile = windowQuality{MaxWidth: 800, Quality: 40}
-	s.profileExplicit = true
-	s.applyAutomaticQuality()
-	if s.profile != (windowQuality{MaxWidth: 800, Quality: 40}) {
-		t.Fatalf("automatic profile overwrote explicit request: %+v", s.profile)
+func TestLegacyViewerKeepsExistingCaptureProfile(t *testing.T) {
+	// Viewers predating quality requests send no profile. Keep their capture
+	// behavior unchanged until updated viewer HTML explicitly asks to sharpen.
+	got := (windowQuality{}).normalized()
+	want := windowQuality{MaxWidth: winMaxWidth, Quality: winCaptureQuality}
+	if got != want {
+		t.Fatalf("legacy viewer profile = %+v, want %+v", got, want)
 	}
 }

--- a/internal/client/windows.go
+++ b/internal/client/windows.go
@@ -1362,14 +1362,13 @@ func (s winSinks) expectsAck() bool { return len(s.confirmed) > 0 || s.ws }
 // winStream is the state machine for one mirrored window. One runs per
 // streamed id (see startWindowStream); all fields are goroutine-local.
 type winStream struct {
-	a               *Agent
-	b               windowBackend
-	w               winInfo
-	stop            <-chan struct{}
-	ack             <-chan uint64
-	quality         <-chan windowQuality
-	profile         windowQuality
-	profileExplicit bool
+	a       *Agent
+	b       windowBackend
+	w       winInfo
+	stop    <-chan struct{}
+	ack     <-chan uint64
+	quality <-chan windowQuality
+	profile windowQuality
 	// forceSend makes the next capture ship whatever the change detector
 	// thinks, and bypasses the relay pacing while it does. Raised for a viewer
 	// that has joined an in-flight stream and has no picture at all; cleared
@@ -1512,7 +1511,6 @@ func (s *winStream) run() {
 			return
 		}
 		s.negotiateCodec()
-		s.applyAutomaticQuality()
 		// A viewer lost sync (gap in the sequence): re-key before capturing, so
 		// the very next AU it receives is a self-contained entry point.
 		s.noteKeyRequest()
@@ -1598,29 +1596,10 @@ func (s *winStream) applyQuality() {
 			if !changed || newest == s.profile {
 				return
 			}
-			s.profileExplicit = true
 			s.setQuality(newest)
 			return
 		}
 	}
-}
-
-// applyAutomaticQuality keeps locally modified agents useful with the official
-// hosted viewer, which cannot know about a newly-added quality request yet.
-// Relay traffic gets a conservative sharper tier; when every viewer is on a
-// confirmed P2P channel, the stream can spend more pixels without loading the
-// shared service. A viewer that explicitly requested a profile remains the
-// authority (notably Save-Data/2G browsers).
-func (s *winStream) applyAutomaticQuality() {
-	if s.profileExplicit {
-		return
-	}
-	confirmed, _, _ := s.a.rtcSinks()
-	want := windowQuality{MaxWidth: 1920, Quality: 68}
-	if len(confirmed) > 0 && !wsSinkNeeded(s.a.framesWantedBy(), len(confirmed)) {
-		want = windowQuality{MaxWidth: 2880, Quality: 80}
-	}
-	s.setQuality(want)
 }
 
 func (s *winStream) setQuality(q windowQuality) {

--- a/internal/client/windows.go
+++ b/internal/client/windows.go
@@ -307,7 +307,9 @@ func (a *Agent) handleWindowCtl(encData string) {
 		// one viewer closing a pane stopped the stream for everyone watching
 		// that window. Absent for viewers older than this field, which keeps
 		// their old all-or-nothing behaviour.
-		Viewer string `json:"viewer"`
+		Viewer   string `json:"viewer"`
+		MaxWidth int    `json:"max_width"`
+		Quality  int    `json:"quality"`
 	}
 	if json.Unmarshal(plaintext, &req) != nil {
 		return
@@ -315,12 +317,63 @@ func (a *Agent) handleWindowCtl(encData string) {
 	switch req.Action {
 	case "start":
 		a.startWindowStream(req.ID, req.Viewer)
+		// Old/official viewers omit these fields. Leave those streams in host-side
+		// auto mode so they still sharpen when WebRTC becomes direct.
+		if req.MaxWidth != 0 || req.Quality != 0 {
+			a.tuneWindowStream(req.ID, windowQuality{MaxWidth: req.MaxWidth, Quality: req.Quality})
+		}
+	case "quality":
+		a.tuneWindowStream(req.ID, windowQuality{MaxWidth: req.MaxWidth, Quality: req.Quality})
 	case "stop":
 		if a.dropWindowSub(req.ID, req.Viewer) {
 			return // somebody else is still watching this window
 		}
 		a.stopWindowStream(req.ID)
 		a.releaseWindowInput() // never leave a button held after a pane closes
+	}
+}
+
+// windowQuality is a viewer-requested capture profile. Values are deliberately
+// bounded on the host: a browser is an authenticated remote input, not a source
+// we trust with arbitrary encoder sizes or CPU usage.
+type windowQuality struct {
+	MaxWidth int
+	Quality  int
+}
+
+func (q windowQuality) normalized() windowQuality {
+	if q.MaxWidth == 0 {
+		q.MaxWidth = winMaxWidth
+	}
+	if q.Quality == 0 {
+		q.Quality = winCaptureQuality
+	}
+	q.MaxWidth = max(720, min(2880, q.MaxWidth))
+	q.Quality = max(35, min(82, q.Quality))
+	return q
+}
+
+// tuneWindowStream replaces any stale pending profile with the newest one.
+// Resizing a pane can emit several requests; only its final size matters.
+func (a *Agent) tuneWindowStream(id string, q windowQuality) {
+	q = q.normalized()
+	a.winMu.Lock()
+	ch := a.winQuality[id]
+	a.winMu.Unlock()
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- q:
+	default:
+		select {
+		case <-ch:
+		default:
+		}
+		select {
+		case ch <- q:
+		default:
+		}
 	}
 }
 
@@ -569,6 +622,11 @@ func (a *Agent) startWindowStream(id, viewer string) {
 		a.winAck = map[string]chan uint64{}
 		a.winKeyReq = map[string]*atomic.Bool{}
 	}
+	// Keep this independent of winStreams for tests and hot-restart state made
+	// by an older image, where the pre-existing maps do not include quality.
+	if a.winQuality == nil {
+		a.winQuality = map[string]chan windowQuality{}
+	}
 	if _, ok := a.winStreams[id]; ok {
 		a.winMu.Unlock() // already streaming this window
 		// Somebody new just asked for it, though. H.264 deltas are useless
@@ -583,9 +641,11 @@ func (a *Agent) startWindowStream(id, viewer string) {
 	// Buffered so an incoming ack never blocks the reader goroutine; streamWindow
 	// only cares about the newest seq, so a slot or two is plenty.
 	ack := make(chan uint64, 4)
+	quality := make(chan windowQuality, 1)
 	keyReq := &atomic.Bool{}
 	a.winStreams[id] = stop
 	a.winAck[id] = ack
+	a.winQuality[id] = quality
 	a.winKeyReq[id] = keyReq
 	// First window under mirror → keep the display awake so the host can't
 	// idle-lock and strand remote control (see winAwake).
@@ -594,7 +654,7 @@ func (a *Agent) startWindowStream(id, viewer string) {
 	}
 	a.winMu.Unlock()
 
-	go a.streamWindow(w, stop, ack, keyReq)
+	go a.streamWindow(w, stop, ack, quality, keyReq)
 }
 
 // stopWindowStream ends the stream for one window id (its pane was closed).
@@ -608,11 +668,13 @@ func (a *Agent) stopWindowStream(id string) {
 			delete(a.winStreams, k)
 		}
 		a.winAck = map[string]chan uint64{}
+		a.winQuality = map[string]chan windowQuality{}
 		a.winKeyReq = map[string]*atomic.Bool{}
 	} else if ch, ok := a.winStreams[id]; ok {
 		close(ch)
 		delete(a.winStreams, id)
 		delete(a.winAck, id)
+		delete(a.winQuality, id)
 		delete(a.winKeyReq, id)
 	}
 	// Last window stopped → let the display sleep/lock again. Capture and run the
@@ -1300,11 +1362,14 @@ func (s winSinks) expectsAck() bool { return len(s.confirmed) > 0 || s.ws }
 // winStream is the state machine for one mirrored window. One runs per
 // streamed id (see startWindowStream); all fields are goroutine-local.
 type winStream struct {
-	a    *Agent
-	b    windowBackend
-	w    winInfo
-	stop <-chan struct{}
-	ack  <-chan uint64
+	a               *Agent
+	b               windowBackend
+	w               winInfo
+	stop            <-chan struct{}
+	ack             <-chan uint64
+	quality         <-chan windowQuality
+	profile         windowQuality
+	profileExplicit bool
 	// forceSend makes the next capture ship whatever the change detector
 	// thinks, and bypasses the relay pacing while it does. Raised for a viewer
 	// that has joined an in-flight stream and has no picture at all; cleared
@@ -1381,8 +1446,8 @@ type winStream struct {
 // the viewer acks one over them. The stream is ack-paced: at most
 // maxFramesInFlight unacknowledged frames, so latency can't accumulate on a
 // slow link and the rate adapts to what the viewer actually consumes.
-func (a *Agent) streamWindow(w winInfo, stop <-chan struct{}, ack <-chan uint64, keyReq *atomic.Bool) {
-	s := &winStream{a: a, b: a.windows(), w: w, stop: stop, ack: ack, keyReq: keyReq, lastGeoCheck: time.Now()}
+func (a *Agent) streamWindow(w winInfo, stop <-chan struct{}, ack <-chan uint64, quality <-chan windowQuality, keyReq *atomic.Bool) {
+	s := &winStream{a: a, b: a.windows(), w: w, stop: stop, ack: ack, quality: quality, profile: (windowQuality{}).normalized(), keyReq: keyReq, lastGeoCheck: time.Now()}
 	defer s.cleanup()
 	s.run()
 }
@@ -1400,6 +1465,7 @@ func (s *winStream) cleanup() {
 	if ch, ok := a.winStreams[s.w.ID]; ok && ch == s.stop {
 		delete(a.winStreams, s.w.ID)
 		delete(a.winAck, s.w.ID)
+		delete(a.winQuality, s.w.ID)
 		delete(a.winKeyReq, s.w.ID)
 	}
 	delete(a.winMenu, s.w.ID)
@@ -1438,6 +1504,7 @@ func (s *winStream) run() {
 			return
 		}
 		s.drainAcks()
+		s.applyQuality()
 		if !s.watched() {
 			return
 		}
@@ -1445,6 +1512,7 @@ func (s *winStream) run() {
 			return
 		}
 		s.negotiateCodec()
+		s.applyAutomaticQuality()
 		// A viewer lost sync (gap in the sequence): re-key before capturing, so
 		// the very next AU it receives is a self-contained entry point.
 		s.noteKeyRequest()
@@ -1516,6 +1584,59 @@ func (s *winStream) run() {
 	}
 }
 
+// applyQuality applies the latest browser profile at a frame boundary. The
+// helper is restarted only when the profile actually changes; the old canvas
+// remains visible in the browser until the first sharper frame arrives.
+func (s *winStream) applyQuality() {
+	var newest windowQuality
+	changed := false
+	for {
+		select {
+		case newest = <-s.quality:
+			changed = true
+		default:
+			if !changed || newest == s.profile {
+				return
+			}
+			s.profileExplicit = true
+			s.setQuality(newest)
+			return
+		}
+	}
+}
+
+// applyAutomaticQuality keeps locally modified agents useful with the official
+// hosted viewer, which cannot know about a newly-added quality request yet.
+// Relay traffic gets a conservative sharper tier; when every viewer is on a
+// confirmed P2P channel, the stream can spend more pixels without loading the
+// shared service. A viewer that explicitly requested a profile remains the
+// authority (notably Save-Data/2G browsers).
+func (s *winStream) applyAutomaticQuality() {
+	if s.profileExplicit {
+		return
+	}
+	confirmed, _, _ := s.a.rtcSinks()
+	want := windowQuality{MaxWidth: 1920, Quality: 68}
+	if len(confirmed) > 0 && !wsSinkNeeded(s.a.framesWantedBy(), len(confirmed)) {
+		want = windowQuality{MaxWidth: 2880, Quality: 80}
+	}
+	s.setQuality(want)
+}
+
+func (s *winStream) setQuality(q windowQuality) {
+	q = q.normalized()
+	if q == s.profile {
+		return
+	}
+	s.profile = q
+	if s.helper != nil {
+		s.helper.stop()
+		s.helper = nil
+	}
+	s.helperRetryAt = time.Time{}
+	s.helperErr = ""
+}
+
 // desiredCodec picks the frame codec and delivery shape for the CURRENT sink
 // topology. H.264 needs every receiver to decode it — the relay is a broadcast,
 // so one incapable viewer means nobody gets video — but it is NOT restricted to
@@ -1540,6 +1661,12 @@ func (s *winStream) desiredCodec() (codec string, wsVideo bool) {
 func (s *winStream) captureFPS() int {
 	if s.codec != "h264" {
 		return winHelperFPS
+	}
+	// Spend the high-quality tier on pixels rather than redundant motion.
+	// 2880-wide UI capture at 60fps exceeds the decoder throughput of many
+	// phones; 30fps stays responsive and looks materially sharper.
+	if s.profile.MaxWidth > 1920 {
+		return 30
 	}
 	if s.wsVideo {
 		return winHelperFPS
@@ -1711,7 +1838,7 @@ func (s *winStream) ensureHelper() {
 	if time.Now().Before(s.helperRetryAt) {
 		return
 	}
-	h, err := startCaptureHelper(s.w.ID, winMaxWidth, winCaptureQuality, s.captureFPS(), s.codec)
+	h, err := startCaptureHelper(s.w.ID, s.profile.MaxWidth, s.profile.Quality, s.captureFPS(), s.codec)
 	if err == nil {
 		s.helper = h
 		s.helperErr = ""
@@ -1744,7 +1871,7 @@ func (s *winStream) ensureHelper() {
 		// unavailable). Fall back to JPEG immediately — the viewer is waiting
 		// for frames — and re-test h264 once the suspension lapses.
 		s.suspendH264()
-		if h, jerr := startCaptureHelper(s.w.ID, winMaxWidth, winCaptureQuality, winHelperFPS, ""); jerr == nil {
+		if h, jerr := startCaptureHelper(s.w.ID, s.profile.MaxWidth, s.profile.Quality, winHelperFPS, ""); jerr == nil {
 			s.helper = h
 			s.helperErr = ""
 			s.helperStarted = time.Now()
@@ -1901,7 +2028,7 @@ func (s *winStream) checkWindow(conn *websocket.Conn, changed bool) bool {
 		if resized && s.helper != nil {
 			s.helper.stop()
 			s.helper = nil
-			if h, err := startCaptureHelper(s.w.ID, winMaxWidth, winCaptureQuality, s.captureFPS(), s.codec); err == nil {
+			if h, err := startCaptureHelper(s.w.ID, s.profile.MaxWidth, s.profile.Quality, s.captureFPS(), s.codec); err == nil {
 				s.helper = h
 			} else {
 				s.helperRetryAt = time.Now().Add(helperRetryCooldown)

--- a/native/reminal-capture/main.swift
+++ b/native/reminal-capture/main.swift
@@ -424,7 +424,7 @@ final class H264Encoder {
         guard status == noErr, let created = s else { return nil }
         session = created
 
-        // ~0.08 bits per pixel per frame at 30fps lands at ~1.7 Mbps for
+        // ~0.10 bits per pixel per frame at 30fps lands at ~2.1 Mbps for
         // 1100×636 — measured visually transparent for UI content vs the JPEG
         // stream it replaces. Frame rate scales the budget SUBLINEARLY: at a
         // higher rate consecutive frames differ less, so each costs fewer bits.
@@ -434,7 +434,7 @@ final class H264Encoder {
         // flood a P2P link. Property failures are non-fatal: an encoder that
         // ignores a hint still produces decodable output.
         let fpsScale = pow(Double(fps) / 30.0, 0.6)
-        let avgBitrate = max(600_000, min(6_000_000, Int(Double(width * height) * 30.0 * 0.08 * fpsScale)))
+        let avgBitrate = max(600_000, min(12_000_000, Int(Double(width * height) * 30.0 * 0.10 * fpsScale)))
         VTSessionSetProperty(session, key: kVTCompressionPropertyKey_RealTime, value: kCFBooleanTrue)
         VTSessionSetProperty(session, key: kVTCompressionPropertyKey_ProfileLevel, value: kVTProfileLevel_H264_Main_AutoLevel)
         VTSessionSetProperty(session, key: kVTCompressionPropertyKey_AllowFrameReordering, value: kCFBooleanFalse)


### PR DESCRIPTION
## Summary

- let the browser request a capture profile for each mirrored window
- choose resolution from the pane display size, device pixel ratio, zoom level, transport, and Network Information hints
- use stable 800/1100/1440/1920/2560/2880 width tiers to avoid restarting capture for tiny size changes
- request a sharper profile when a pane is opened, resized, restored, zoomed, or moved between relay and direct WebRTC delivery
- apply new profiles at frame boundaries and restart the native capture helper only when the tier actually changes
- preserve the existing 1100@45 capture profile for older/official viewers until updated browser HTML explicitly requests another tier
- report both the canvas decode resolution and requested profile in the info panel

## Why

The viewer previously captured every window at a fixed width, even when the browser displayed it on a large or Retina pane. A healthy direct WebRTC connection could therefore still look blurry, while small panes could receive more pixels than they could display.

This change matches source pixels to the actual browser viewport. Confirmed direct WebRTC can request up to 2880px at quality 80; a healthy relay route can use up to 2560px, while Save-Data and constrained-network hints select smaller profiles.

## Compatibility and safeguards

- quality fields are optional; older viewers continue to work
- requests are clamped on the host to safe resolution and quality bounds
- resize negotiation is throttled and bucketed to prevent capture-helper churn
- older viewers keep their existing capture defaults; only explicit browser requests change quality
- high-resolution H.264 capture uses 30fps to favor readable UI detail and mobile decoder stability

## Testing

- `go test ./internal/client ./internal/relay`
- added tests for profile defaults and bounds, newest-request coalescing, and legacy-viewer compatibility
- verified the embedded and Cloudflare viewer HTML files are byte-identical

## Merge order

This PR is independent and can be merged in any order. If another viewer-related PR lands first, this branch may only need a conflict-only rebase because multiple PRs update the embedded and Cloudflare-hosted HTML copies. The branch should be retested after that rebase.