### PR TITLE
Isolate window-pane gestures and improve mobile pan and drag

### DIFF
--- a/cloudflare/public/index.html
+++ b/cloudflare/public/index.html
@@ -950,7 +950,7 @@
        it where there's a real pointer with hover (desktop). */
     .wpane-kbd { display: none; }
     @media (any-pointer: coarse) { .wpane-kbd { display: inline-flex; } }
-    .wpane-body { position: relative; background: #000; line-height: 0; overflow: hidden; }
+    .wpane-body { position: relative; background: #000; line-height: 0; overflow: hidden; overscroll-behavior: contain; }
     /* Standalone pane mode (?pane=): the window fills the tab. The pane keeps
        its own title bar so keyboard and info stay reachable; pop-out and close
        go, since this tab IS the pane. */
@@ -2125,6 +2125,7 @@
     // second ✂ tap, or a tap anywhere outside it.
     document.addEventListener('pointerdown', (e) => {
       if (!snipdockManage) return;
+      if (e.target.closest('.wpane')) return; // window gestures are an isolated input surface
       if (snipdockEl.contains(e.target) || snipHandle.contains(e.target)) return;
       closeSnipdock();
     }, true);
@@ -6729,6 +6730,7 @@
       // (which we exclude), and before xterm re-selects on a fresh press.
       document.addEventListener('pointerdown', (e) => {
         if (!active) return;
+        if (e.target.closest('.wpane')) return; // don't let pane gestures mutate terminal selection
         if (e.target.closest('#sel-toolbar, #sel-handle-start, #sel-handle-end')) return;
         clearSelection();
         // A tap on the terminal itself will fire a follow-up click; swallow it
@@ -7564,7 +7566,23 @@
       paneDrag(pane, bar);
       paneResize(pane, rz);
       paneInput(pane, img);
-      el.addEventListener('pointerdown', () => focusPane(w.id));
+      // A pane is its own gesture surface. Stop bubbling pointer/touch/wheel
+      // events into page-level docks, terminal selection and scroll handlers.
+      // Target handlers still run first; this fence is on the pane's bubble
+      // phase, while the capture-phase globals explicitly ignore .wpane above.
+      el.addEventListener('pointerdown', (e) => { e.stopPropagation(); focusPane(w.id); });
+      for (const type of ['pointermove', 'pointerup', 'pointercancel', 'click', 'dblclick', 'contextmenu', 'wheel']) {
+        el.addEventListener(type, (e) => e.stopPropagation());
+      }
+      for (const type of ['touchstart', 'touchmove', 'touchend', 'touchcancel']) {
+        el.addEventListener(type, (e) => {
+          e.stopPropagation();
+          if (type === 'touchmove') e.preventDefault();
+        }, { passive: false });
+      }
+      for (const type of ['gesturestart', 'gesturechange', 'gestureend']) {
+        el.addEventListener(type, (e) => { e.preventDefault(); e.stopPropagation(); }, { passive: false });
+      }
       closeBtn.addEventListener('click', (e) => { e.stopPropagation(); closePane(w.id); });
       popBtn.addEventListener('click', (e) => { e.stopPropagation(); popOutPane(pane); });
       kbdBtn.addEventListener('click', (e) => {
@@ -8799,10 +8817,10 @@
         if (ptrs.size === 2 && e.pointerType !== 'mouse') {
           const [a, b] = [...ptrs.values()];
           const cx = (a.x + b.x) / 2, cy = (a.y + b.y) / 2, d0 = dist(a, b);
-          // Two-finger gesture: locked to 'zoom' (fingers spread → pinch-zoom the
-          // pane) or 'scroll' (fingers move together → scroll the window) on the
-          // first decisive movement, so the two don't fight each other.
-          pinch = { d: d0 || 1, mx: cx, my: cy, z: pane.zoom, px: pane.panX, py: pane.panY, startD: d0, lastCx: cx, lastCy: cy, mode: null, t: Date.now() };
+          // Once zoomed, two fingers always manipulate the local viewport:
+          // changing their distance zooms and moving their midpoint pans. At
+          // 1×, a parallel two-finger swipe still scrolls the remote app.
+          pinch = { d: d0 || 1, mx: cx, my: cy, z: pane.zoom, px: pane.panX, py: pane.panY, startD: d0, lastCx: cx, lastCy: cy, mode: pane.zoom > 1.001 ? 'view' : null, t: Date.now() };
           downAt = 0; path = null; endDrag(false);
           return;
         }
@@ -8831,10 +8849,14 @@
           const [a, b] = [...ptrs.values()];
           const d = dist(a, b), cx = (a.x + b.x) / 2, cy = (a.y + b.y) / 2;
           if (!pinch.mode) {
-            if (Math.abs(d - pinch.startD) > 16) pinch.mode = 'zoom';
+            if (Math.abs(d - pinch.startD) > 16) pinch.mode = 'view';
             else if (Math.hypot(cx - pinch.mx, cy - pinch.my) > 16) pinch.mode = 'scroll';
           }
-          if (pinch.mode === 'zoom') {
+          if (pinch.mode === 'view') {
+            // Zoom and pan are applied together. The old zoom-only branch did
+            // move the midpoint while pinching, but a fresh parallel gesture
+            // on an already-zoomed image was classified as remote scrolling,
+            // making the enlarged viewport effectively impossible to drag.
             pane.zoom = Math.max(1, Math.min(MAX_ZOOM, pinch.z * (d / pinch.d)));
             pane.panX = pinch.px + (cx - pinch.mx);
             pane.panY = pinch.py + (cy - pinch.my);
@@ -8858,7 +8880,10 @@
           if (mouseBtn === 0 && moved && dragPhasesOK()) {
             const f = frac(e);
             if (!dragLive) dragBegin(path && path.length ? path[0] : f);
-            else dragMove(f);
+            // Include the threshold-crossing movement itself. Previously the
+            // first move only pressed the button; a quick release then had no
+            // dragged event, so many apps treated it as a click, not a drag.
+            dragMove(f);
           }
           return;
         }
@@ -8927,7 +8952,7 @@
       img.addEventListener('pointercancel', endPointer);
       // Desktop: mouse wheel / trackpad scroll over the pane scrolls the window.
       img.addEventListener('wheel', (e) => {
-        e.preventDefault();
+        e.preventDefault(); e.stopPropagation();
         focusPane(pane.w.id);
         const f = frac(e);
         const m = e.deltaMode === 1 ? 16 : (e.deltaMode === 2 ? img.getBoundingClientRect().height : 1);

--- a/cloudflare/public/index.html
+++ b/cloudflare/public/index.html
@@ -6820,7 +6820,8 @@
 
     // Close the recents <details> on any outside click. Native <details>
     // doesn't have this behavior — only the summary toggles it — so a
-    // dropdown left open after picking a row would shadow the terminal.
+    // dropdown left open after picking a row would shadow the terminal. This
+    // runs in capture phase so pane click isolation cannot hide an outside tap.
     document.addEventListener('click', (e) => {
       const recents = document.getElementById('recents');
       if (recents && recents.open && !recents.contains(e.target)) {
@@ -6838,7 +6839,7 @@
       if (host && host.open && !host.contains(e.target)) {
         host.open = false;
       }
-    });
+    }, true);
     // While the Host dropdown is open, poll the stats live and refresh the
     // panel; stop polling when it closes.
     let hostPollTimer = null;
@@ -7577,6 +7578,9 @@
       for (const type of ['touchstart', 'touchmove', 'touchend', 'touchcancel']) {
         el.addEventListener(type, (e) => {
           e.stopPropagation();
+          // The pane currently owns every touch gesture. If native scrollable
+          // or selectable controls are added inside it later, exempt those
+          // targets here before preventing touchmove's browser default.
           if (type === 'touchmove') e.preventDefault();
         }, { passive: false });
       }
@@ -8817,10 +8821,11 @@
         if (ptrs.size === 2 && e.pointerType !== 'mouse') {
           const [a, b] = [...ptrs.values()];
           const cx = (a.x + b.x) / 2, cy = (a.y + b.y) / 2, d0 = dist(a, b);
-          // Once zoomed, two fingers always manipulate the local viewport:
-          // changing their distance zooms and moving their midpoint pans. At
-          // 1×, a parallel two-finger swipe still scrolls the remote app.
-          pinch = { d: d0 || 1, mx: cx, my: cy, z: pane.zoom, px: pane.panX, py: pane.panY, startD: d0, lastCx: cx, lastCy: cy, mode: pane.zoom > 1.001 ? 'view' : null, t: Date.now() };
+          // Both pinch and parallel movement enter one deterministic viewport
+          // mode. Midpoint movement pans while room remains; any movement the
+          // pan bounds cannot consume chains into remote scrolling. At 1×
+          // there is no pan room, so a parallel swipe scrolls immediately.
+          pinch = { d: d0 || 1, mx: cx, my: cy, z: pane.zoom, startD: d0, lastCx: cx, lastCy: cy, mode: null, scaled: false, t: Date.now() };
           downAt = 0; path = null; endDrag(false);
           return;
         }
@@ -8848,25 +8853,34 @@
         if (pinch && ptrs.size >= 2) {
           const [a, b] = [...ptrs.values()];
           const d = dist(a, b), cx = (a.x + b.x) / 2, cy = (a.y + b.y) / 2;
+          const fingerDX = cx - pinch.lastCx, fingerDY = cy - pinch.lastCy;
+          const scaleMoved = Math.abs(d - pinch.startD) > 16;
+          const midpointMoved = Math.hypot(cx - pinch.mx, cy - pinch.my) > 16;
           if (!pinch.mode) {
-            if (Math.abs(d - pinch.startD) > 16) pinch.mode = 'view';
-            else if (Math.hypot(cx - pinch.mx, cy - pinch.my) > 16) pinch.mode = 'scroll';
+            if (scaleMoved || midpointMoved) pinch.mode = 'view';
           }
+          if (scaleMoved) pinch.scaled = true;
           if (pinch.mode === 'view') {
-            // Zoom and pan are applied together. The old zoom-only branch did
-            // move the midpoint while pinching, but a fresh parallel gesture
-            // on an already-zoomed image was classified as remote scrolling,
-            // making the enlarged viewport effectively impossible to drag.
-            pane.zoom = Math.max(1, Math.min(MAX_ZOOM, pinch.z * (d / pinch.d)));
-            pane.panX = pinch.px + (cx - pinch.mx);
-            pane.panY = pinch.py + (cy - pinch.my);
+            // Once a real distance change wins the threshold, keep the whole
+            // gesture local: combined pinch+pan must not accidentally scroll.
+            if (pinch.scaled) pane.zoom = Math.max(1, Math.min(MAX_ZOOM, pinch.z * (d / pinch.d)));
+            const beforeX = pane.panX, beforeY = pane.panY;
+            pane.panX += fingerDX;
+            pane.panY += fingerDY;
             clampPan(); applyTransform();
-          } else if (pinch.mode === 'scroll') {
-            // Map finger travel to window pixels (the pane is downscaled) so the
-            // content tracks the fingers. Fingers up → scroll down.
-            const rr = img.getBoundingClientRect();
-            const scaleX = (pane.w.w || rr.width) / rr.width, scaleY = (pane.w.h || rr.height) / rr.height;
-            queueScroll(fracAt(cx, cy).fx, fracAt(cx, cy).fy, (pinch.lastCx - cx) * scaleX, (pinch.lastCy - cy) * scaleY);
+            if (!pinch.scaled) {
+              // Nested-scroll chaining: consume midpoint travel as local pan
+              // first, then send only the remainder once an axis reaches its
+              // edge. Incremental pan avoids a dead zone when reversing there.
+              const residualX = fingerDX - (pane.panX - beforeX);
+              const residualY = fingerDY - (pane.panY - beforeY);
+              if (Math.abs(residualX) > 0.25 || Math.abs(residualY) > 0.25) {
+                const rr = img.getBoundingClientRect();
+                const scaleX = (pane.w.w || rr.width) / rr.width, scaleY = (pane.w.h || rr.height) / rr.height;
+                const f = fracAt(cx, cy);
+                queueScroll(f.fx, f.fy, -residualX * scaleX, -residualY * scaleY);
+              }
+            }
           }
           pinch.lastCx = cx; pinch.lastCy = cy;
           return;

--- a/internal/client/mirror_scroll_test.go
+++ b/internal/client/mirror_scroll_test.go
@@ -382,6 +382,10 @@ func TestAbandonedDragReleasesTheButton(t *testing.T) {
 		if ups != 1 {
 			t.Fatalf("got %d releases, want exactly 1", ups)
 		}
+		got := b.got()
+		if len(got) < 3 || got[len(got)-2] != "move" || got[len(got)-1] != "up" {
+			t.Fatalf("clean end phases = %v, want a final move before up", got)
+		}
 	})
 }
 

--- a/internal/client/web/index.html
+++ b/internal/client/web/index.html
@@ -950,7 +950,7 @@
        it where there's a real pointer with hover (desktop). */
     .wpane-kbd { display: none; }
     @media (any-pointer: coarse) { .wpane-kbd { display: inline-flex; } }
-    .wpane-body { position: relative; background: #000; line-height: 0; overflow: hidden; }
+    .wpane-body { position: relative; background: #000; line-height: 0; overflow: hidden; overscroll-behavior: contain; }
     /* Standalone pane mode (?pane=): the window fills the tab. The pane keeps
        its own title bar so keyboard and info stay reachable; pop-out and close
        go, since this tab IS the pane. */
@@ -2125,6 +2125,7 @@
     // second ✂ tap, or a tap anywhere outside it.
     document.addEventListener('pointerdown', (e) => {
       if (!snipdockManage) return;
+      if (e.target.closest('.wpane')) return; // window gestures are an isolated input surface
       if (snipdockEl.contains(e.target) || snipHandle.contains(e.target)) return;
       closeSnipdock();
     }, true);
@@ -6729,6 +6730,7 @@
       // (which we exclude), and before xterm re-selects on a fresh press.
       document.addEventListener('pointerdown', (e) => {
         if (!active) return;
+        if (e.target.closest('.wpane')) return; // don't let pane gestures mutate terminal selection
         if (e.target.closest('#sel-toolbar, #sel-handle-start, #sel-handle-end')) return;
         clearSelection();
         // A tap on the terminal itself will fire a follow-up click; swallow it
@@ -7564,7 +7566,23 @@
       paneDrag(pane, bar);
       paneResize(pane, rz);
       paneInput(pane, img);
-      el.addEventListener('pointerdown', () => focusPane(w.id));
+      // A pane is its own gesture surface. Stop bubbling pointer/touch/wheel
+      // events into page-level docks, terminal selection and scroll handlers.
+      // Target handlers still run first; this fence is on the pane's bubble
+      // phase, while the capture-phase globals explicitly ignore .wpane above.
+      el.addEventListener('pointerdown', (e) => { e.stopPropagation(); focusPane(w.id); });
+      for (const type of ['pointermove', 'pointerup', 'pointercancel', 'click', 'dblclick', 'contextmenu', 'wheel']) {
+        el.addEventListener(type, (e) => e.stopPropagation());
+      }
+      for (const type of ['touchstart', 'touchmove', 'touchend', 'touchcancel']) {
+        el.addEventListener(type, (e) => {
+          e.stopPropagation();
+          if (type === 'touchmove') e.preventDefault();
+        }, { passive: false });
+      }
+      for (const type of ['gesturestart', 'gesturechange', 'gestureend']) {
+        el.addEventListener(type, (e) => { e.preventDefault(); e.stopPropagation(); }, { passive: false });
+      }
       closeBtn.addEventListener('click', (e) => { e.stopPropagation(); closePane(w.id); });
       popBtn.addEventListener('click', (e) => { e.stopPropagation(); popOutPane(pane); });
       kbdBtn.addEventListener('click', (e) => {
@@ -8799,10 +8817,10 @@
         if (ptrs.size === 2 && e.pointerType !== 'mouse') {
           const [a, b] = [...ptrs.values()];
           const cx = (a.x + b.x) / 2, cy = (a.y + b.y) / 2, d0 = dist(a, b);
-          // Two-finger gesture: locked to 'zoom' (fingers spread → pinch-zoom the
-          // pane) or 'scroll' (fingers move together → scroll the window) on the
-          // first decisive movement, so the two don't fight each other.
-          pinch = { d: d0 || 1, mx: cx, my: cy, z: pane.zoom, px: pane.panX, py: pane.panY, startD: d0, lastCx: cx, lastCy: cy, mode: null, t: Date.now() };
+          // Once zoomed, two fingers always manipulate the local viewport:
+          // changing their distance zooms and moving their midpoint pans. At
+          // 1×, a parallel two-finger swipe still scrolls the remote app.
+          pinch = { d: d0 || 1, mx: cx, my: cy, z: pane.zoom, px: pane.panX, py: pane.panY, startD: d0, lastCx: cx, lastCy: cy, mode: pane.zoom > 1.001 ? 'view' : null, t: Date.now() };
           downAt = 0; path = null; endDrag(false);
           return;
         }
@@ -8831,10 +8849,14 @@
           const [a, b] = [...ptrs.values()];
           const d = dist(a, b), cx = (a.x + b.x) / 2, cy = (a.y + b.y) / 2;
           if (!pinch.mode) {
-            if (Math.abs(d - pinch.startD) > 16) pinch.mode = 'zoom';
+            if (Math.abs(d - pinch.startD) > 16) pinch.mode = 'view';
             else if (Math.hypot(cx - pinch.mx, cy - pinch.my) > 16) pinch.mode = 'scroll';
           }
-          if (pinch.mode === 'zoom') {
+          if (pinch.mode === 'view') {
+            // Zoom and pan are applied together. The old zoom-only branch did
+            // move the midpoint while pinching, but a fresh parallel gesture
+            // on an already-zoomed image was classified as remote scrolling,
+            // making the enlarged viewport effectively impossible to drag.
             pane.zoom = Math.max(1, Math.min(MAX_ZOOM, pinch.z * (d / pinch.d)));
             pane.panX = pinch.px + (cx - pinch.mx);
             pane.panY = pinch.py + (cy - pinch.my);
@@ -8858,7 +8880,10 @@
           if (mouseBtn === 0 && moved && dragPhasesOK()) {
             const f = frac(e);
             if (!dragLive) dragBegin(path && path.length ? path[0] : f);
-            else dragMove(f);
+            // Include the threshold-crossing movement itself. Previously the
+            // first move only pressed the button; a quick release then had no
+            // dragged event, so many apps treated it as a click, not a drag.
+            dragMove(f);
           }
           return;
         }
@@ -8927,7 +8952,7 @@
       img.addEventListener('pointercancel', endPointer);
       // Desktop: mouse wheel / trackpad scroll over the pane scrolls the window.
       img.addEventListener('wheel', (e) => {
-        e.preventDefault();
+        e.preventDefault(); e.stopPropagation();
         focusPane(pane.w.id);
         const f = frac(e);
         const m = e.deltaMode === 1 ? 16 : (e.deltaMode === 2 ? img.getBoundingClientRect().height : 1);

--- a/internal/client/web/index.html
+++ b/internal/client/web/index.html
@@ -6820,7 +6820,8 @@
 
     // Close the recents <details> on any outside click. Native <details>
     // doesn't have this behavior — only the summary toggles it — so a
-    // dropdown left open after picking a row would shadow the terminal.
+    // dropdown left open after picking a row would shadow the terminal. This
+    // runs in capture phase so pane click isolation cannot hide an outside tap.
     document.addEventListener('click', (e) => {
       const recents = document.getElementById('recents');
       if (recents && recents.open && !recents.contains(e.target)) {
@@ -6838,7 +6839,7 @@
       if (host && host.open && !host.contains(e.target)) {
         host.open = false;
       }
-    });
+    }, true);
     // While the Host dropdown is open, poll the stats live and refresh the
     // panel; stop polling when it closes.
     let hostPollTimer = null;
@@ -7577,6 +7578,9 @@
       for (const type of ['touchstart', 'touchmove', 'touchend', 'touchcancel']) {
         el.addEventListener(type, (e) => {
           e.stopPropagation();
+          // The pane currently owns every touch gesture. If native scrollable
+          // or selectable controls are added inside it later, exempt those
+          // targets here before preventing touchmove's browser default.
           if (type === 'touchmove') e.preventDefault();
         }, { passive: false });
       }
@@ -8817,10 +8821,11 @@
         if (ptrs.size === 2 && e.pointerType !== 'mouse') {
           const [a, b] = [...ptrs.values()];
           const cx = (a.x + b.x) / 2, cy = (a.y + b.y) / 2, d0 = dist(a, b);
-          // Once zoomed, two fingers always manipulate the local viewport:
-          // changing their distance zooms and moving their midpoint pans. At
-          // 1×, a parallel two-finger swipe still scrolls the remote app.
-          pinch = { d: d0 || 1, mx: cx, my: cy, z: pane.zoom, px: pane.panX, py: pane.panY, startD: d0, lastCx: cx, lastCy: cy, mode: pane.zoom > 1.001 ? 'view' : null, t: Date.now() };
+          // Both pinch and parallel movement enter one deterministic viewport
+          // mode. Midpoint movement pans while room remains; any movement the
+          // pan bounds cannot consume chains into remote scrolling. At 1×
+          // there is no pan room, so a parallel swipe scrolls immediately.
+          pinch = { d: d0 || 1, mx: cx, my: cy, z: pane.zoom, startD: d0, lastCx: cx, lastCy: cy, mode: null, scaled: false, t: Date.now() };
           downAt = 0; path = null; endDrag(false);
           return;
         }
@@ -8848,25 +8853,34 @@
         if (pinch && ptrs.size >= 2) {
           const [a, b] = [...ptrs.values()];
           const d = dist(a, b), cx = (a.x + b.x) / 2, cy = (a.y + b.y) / 2;
+          const fingerDX = cx - pinch.lastCx, fingerDY = cy - pinch.lastCy;
+          const scaleMoved = Math.abs(d - pinch.startD) > 16;
+          const midpointMoved = Math.hypot(cx - pinch.mx, cy - pinch.my) > 16;
           if (!pinch.mode) {
-            if (Math.abs(d - pinch.startD) > 16) pinch.mode = 'view';
-            else if (Math.hypot(cx - pinch.mx, cy - pinch.my) > 16) pinch.mode = 'scroll';
+            if (scaleMoved || midpointMoved) pinch.mode = 'view';
           }
+          if (scaleMoved) pinch.scaled = true;
           if (pinch.mode === 'view') {
-            // Zoom and pan are applied together. The old zoom-only branch did
-            // move the midpoint while pinching, but a fresh parallel gesture
-            // on an already-zoomed image was classified as remote scrolling,
-            // making the enlarged viewport effectively impossible to drag.
-            pane.zoom = Math.max(1, Math.min(MAX_ZOOM, pinch.z * (d / pinch.d)));
-            pane.panX = pinch.px + (cx - pinch.mx);
-            pane.panY = pinch.py + (cy - pinch.my);
+            // Once a real distance change wins the threshold, keep the whole
+            // gesture local: combined pinch+pan must not accidentally scroll.
+            if (pinch.scaled) pane.zoom = Math.max(1, Math.min(MAX_ZOOM, pinch.z * (d / pinch.d)));
+            const beforeX = pane.panX, beforeY = pane.panY;
+            pane.panX += fingerDX;
+            pane.panY += fingerDY;
             clampPan(); applyTransform();
-          } else if (pinch.mode === 'scroll') {
-            // Map finger travel to window pixels (the pane is downscaled) so the
-            // content tracks the fingers. Fingers up → scroll down.
-            const rr = img.getBoundingClientRect();
-            const scaleX = (pane.w.w || rr.width) / rr.width, scaleY = (pane.w.h || rr.height) / rr.height;
-            queueScroll(fracAt(cx, cy).fx, fracAt(cx, cy).fy, (pinch.lastCx - cx) * scaleX, (pinch.lastCy - cy) * scaleY);
+            if (!pinch.scaled) {
+              // Nested-scroll chaining: consume midpoint travel as local pan
+              // first, then send only the remainder once an axis reaches its
+              // edge. Incremental pan avoids a dead zone when reversing there.
+              const residualX = fingerDX - (pane.panX - beforeX);
+              const residualY = fingerDY - (pane.panY - beforeY);
+              if (Math.abs(residualX) > 0.25 || Math.abs(residualY) > 0.25) {
+                const rr = img.getBoundingClientRect();
+                const scaleX = (pane.w.w || rr.width) / rr.width, scaleY = (pane.w.h || rr.height) / rr.height;
+                const f = fracAt(cx, cy);
+                queueScroll(f.fx, f.fy, -residualX * scaleX, -residualY * scaleY);
+              }
+            }
           }
           pinch.lastCx = cx; pinch.lastCy = cy;
           return;

--- a/internal/client/web_sync_test.go
+++ b/internal/client/web_sync_test.go
@@ -6,6 +6,7 @@ package client
 import (
 	"crypto/sha256"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -34,5 +35,31 @@ func TestWebIndexCopiesInSync(t *testing.T) {
 		t.Fatalf("%s and %s have diverged (%d vs %d bytes).\n"+
 			"After editing the viewer, copy it across:\n"+
 			"  cp %s %s", embedded, worker, len(a), len(b), embedded, worker)
+	}
+}
+
+// These are event-order contracts in the shipped viewer, not styling details:
+// the dropdown listener must run before a pane fences clicks, and a two-finger
+// swipe must preserve both local pan and edge-chained remote scrolling.
+func TestPaneGestureContracts(t *testing.T) {
+	b, err := os.ReadFile("web/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, required := range []string{
+		"runs in capture phase so pane click isolation cannot hide an outside tap",
+		"}, true);\n    // While the Host dropdown is open",
+		"mode: null, scaled: false",
+		"const residualX = fingerDX - (pane.panX - beforeX)",
+		"queueScroll(f.fx, f.fy, -residualX * scaleX, -residualY * scaleY)",
+		"targets here before preventing touchmove's browser default",
+	} {
+		if !strings.Contains(s, required) {
+			t.Fatalf("viewer is missing pane gesture contract %q", required)
+		}
+	}
+	if strings.Contains(s, "mode: pane.zoom > 1.001 ? 'view' : null") {
+		t.Fatal("zoomed panes still force local-only view mode; remote edge scrolling is unreachable")
 	}
 }

--- a/internal/client/windows.go
+++ b/internal/client/windows.go
@@ -941,6 +941,13 @@ func applyWindowInput(b windowBackend, st *inputState, ev windowInput, noteMenu 
 			for _, p := range clampPath(ev.Path, winMaxDragPoints) {
 				_ = pd.dragPhase(w, "move", p[0], p[1])
 			}
+			// Compatibility with viewers that began a drag on the first
+			// threshold-crossing pointermove but did not include that movement in
+			// the end packet. A down followed by an up at another coordinate is
+			// not a drag to many apps; guarantee at least one dragged event.
+			if len(ev.Path) == 0 {
+				_ = pd.dragPhase(w, "move", ev.X, ev.Y)
+			}
 			st.drag.disarm()
 			_ = pd.dragPhase(w, "up", ev.X, ev.Y)
 		}


### PR DESCRIPTION
## Summary

- treat each mirrored window pane as an isolated pointer, touch, wheel, and Safari gesture surface
- prevent pane interactions from reaching page-level snippet, terminal-selection, scrolling, and gesture handlers
- contain browser overscroll inside the pane
- use nested two-finger scrolling: pan the magnified viewport first, then send only movement left over at its edges to the remote application
- keep a real pinch gesture local for its full lifetime so zooming cannot accidentally scroll the remote app
- preserve two-finger remote scrolling at 1x, where the local viewport has no pan range
- close open Host/Recents details from pane taps by handling the outside click in capture phase
- send the threshold-crossing pointer movement as part of a drag instead of waiting for a later event
- add a host-side compatibility move so quick drags from older viewers are not interpreted as clicks

## Why

On mobile, a window could be pinch-zoomed but was difficult to move afterward. The same gesture could also leak into global page behavior, changing terminal selection, dismissing UI, or scrolling the surrounding page.

Fast mouse/touch drags had a second edge case: the event that crossed the drag threshold only pressed the remote button. If the user released immediately, some applications saw a click because no moved event had been delivered.

This change gives the pane ownership of its gestures and makes viewport panning, boundary-chained remote scrolling, dropdown dismissal, and remote drag initiation reliable.

## Behavior

- at 1x, two-finger movement scrolls the remote application
- when zoomed, two-finger movement pans the local viewport until an edge is reached, then chains only the remaining delta into remote scrolling
- once finger distance crosses the pinch threshold, the gesture remains local and can combine zoom with pan
- a two-finger tap remains available for remote right-click
- pane wheel events still scroll the remote window but no longer bubble into the page
- title-bar pane positioning and remote application input remain separate
- the touch fence documents where future native scrollable/selectable pane controls must be exempted

## Testing

- `go vet ./...`
- `go test ./...`
- JavaScript syntax validation with `node --check`
- regression assertions for event ordering, gesture chaining, pane isolation, and drag compatibility
- verified the embedded and Cloudflare viewer HTML files are byte-identical

## Merge order

This PR is independent and can be merged in any order. If another viewer-related PR lands first, this branch may only need a conflict-only rebase because multiple PRs update the embedded and Cloudflare-hosted HTML copies. The branch should be retested after that rebase.