### PR TITLE
fix: reminal new returns before the session is joinable on the relay

### DIFF
--- a/internal/client/agent.go
+++ b/internal/client/agent.go
@@ -758,10 +758,10 @@ func (a *Agent) Run() error {
 
 	// Note: the headless startup handshake (writing the spawned session's
 	// credentials to the inherited fd 3) is deliberately NOT done here. It fires
-	// from signalRegistered once the session is joinable — the local attach
-	// socket binding (serveAttach) or the first relay registration, whichever is
-	// first — so `reminal new` reports the session ready as soon as a viewer
-	// could actually join it, offline (local) or on.
+	// from signalRegistered — on relay registration when online (so the printed
+	// URL is joinable the moment `reminal new` returns), or on the first failed
+	// relay dial when offline (still prompt, and the session is locally
+	// attachable). See serveRelay / signalRegistered.
 
 	sessionStart := time.Now()
 	// Deferred so it runs on every clean exit path — shell exit, agent
@@ -886,6 +886,18 @@ func (a *Agent) serveRelay(shellExit <-chan struct{}) error {
 		case <-a.hostEscape:
 			return nil
 		default:
+		}
+
+		// Release the `reminal new` parent when the relay is UNREACHABLE (offline
+		// / nothing listening): the session is only locally attachable, so return
+		// rather than hang out the handshake timeout. On a reachable relay,
+		// runConnection already signalled after authenticate (session is
+		// relay-joinable) — and a transient failure against a reachable relay is
+		// deliberately NOT signalled here, so the parent waits for the retry's
+		// registration and the printed URL is joinable the moment it returns.
+		// sync.Once → a no-op once either path has fired.
+		if isRelayUnreachable(err) {
+			a.signalRegistered()
 		}
 
 		// runConnection returned because pause() closed the WS — don't
@@ -1071,9 +1083,16 @@ func (a *Agent) broadcastSize(cols, rows uint16) {
 }
 
 // signalRegistered releases the parent (`reminal new`) handshake the first time
-// the session becomes joinable — whichever comes first: the local attach socket
-// binding (serveAttach, so `reminal new` returns even with no network) or the
-// first successful relay registration (runConnection). The sync.Once makes all
+// we know how the session is reachable — whichever comes first:
+//   - relay registration succeeded (runConnection, right after authenticate) —
+//     the session is joinable over the relay, so the printed URL works now;
+//   - the first relay attempt failed (serveRelay) — the relay is unreachable
+//     (offline), but the session is still locally attachable, so release rather
+//     than hang.
+//
+// It deliberately does NOT fire merely because the local socket bound: that
+// returned `reminal new` before the relay had the session, so an immediately-
+// opened URL 404'd ("session not found or not ready"). The sync.Once makes all
 // later calls no-ops, so reconnects and the second path don't re-signal. No-op
 // for non-spawned agents (handshakeFD 0).
 func (a *Agent) signalRegistered() {

--- a/internal/client/attach.go
+++ b/internal/client/attach.go
@@ -64,16 +64,14 @@ func (a *Agent) serveAttach(shellExit <-chan struct{}) {
 		return
 	}
 	_ = os.Chmod(path, 0o600)
-	// The session is now joinable on THIS machine with no relay — the active
-	// record is already written (Run persists it before starting us) and the
-	// socket is bound. That's enough to release a `reminal new` parent: a
-	// same-machine viewer can attach right now, online or off. Without this the
-	// spawn handshake only fired after relay registration, so `reminal new` hung
-	// until it timed out whenever the machine was offline — even though the
-	// session was up and locally attachable. signalRegistered is a sync.Once, so
-	// the relay path signalling later (when it connects) is a no-op, and this is
-	// a no-op for a non-spawned agent (no handshake fd).
-	a.signalRegistered()
+	// NB: binding this socket does NOT release the `reminal new` parent. It used
+	// to (so offline `reminal new` wouldn't hang), but that returned before the
+	// relay had registered the session — so opening the printed URL immediately
+	// (e.g. on a phone) hit the relay before the room existed and showed "session
+	// not found or not ready". The parent is now released from serveRelay: on
+	// relay registration when online (URL works right away), or on the first
+	// failed relay dial when offline (still just a second or two). See
+	// signalRegistered.
 	go func() {
 		<-shellExit
 		_ = ln.Close() // unblocks Serve so this returns at shell exit

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -143,6 +143,35 @@ func classify(err error) string {
 	return "Unknown error"
 }
 
+// isRelayUnreachable reports whether a relay-dial error means the relay endpoint
+// can't be reached at all right now — offline, DNS failure, or nothing listening
+// — as opposed to a transient/in-flight error against a reachable relay (a reset,
+// timeout, or protocol hiccup mid-handshake). serveRelay uses it to decide the
+// `reminal new` handshake: unreachable → the session is only locally attachable,
+// so release the parent now; reachable-but-failed → keep retrying so the parent
+// is released on the eventual relay registration (so the printed URL is joinable
+// the moment `reminal new` returns).
+func isRelayUnreachable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.ENETUNREACH) {
+		return true
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+	// Wrapped errors we can't type-match (some platforms/stdlib paths only
+	// surface these as strings).
+	raw := err.Error()
+	return strings.Contains(raw, "no such host") ||
+		strings.Contains(raw, "network is unreachable") ||
+		strings.Contains(raw, "no route to host")
+}
+
 func relayMessageHint(msg string) string {
 	switch {
 	case strings.Contains(msg, "session not found"):


### PR DESCRIPTION
**Bug:** since v3.9.1, `reminal new` returned as soon as the local attach socket bound — before the agent registered the session with the relay. Opening the printed URL immediately (e.g. on a phone) hit the relay before the session room existed → red "session not found or not ready".

**Fix:** release the `reminal new` parent from `serveRelay`:
- **online** — `runConnection` already signals right after `authenticate` (session is relay-registered), so the URL works the moment `reminal new` returns;
- **offline/unreachable** — signal on the first failed dial (`isRelayUnreachable`: DNS failure, ENETUNREACH/EHOSTUNREACH, ECONNREFUSED) so it still returns in ~1s instead of hanging;
- a **transient** failure against a reachable relay is not signalled — the parent waits for the retry's registration rather than racing the URL again.

`serveAttach` no longer signals on bind.

**Verified:** offline `reminal new` returns in ~0.5s; online, a viewer connecting immediately after it returns reaches the session over the real relay (no 'session not found'). Full client suite + cross-compile green.

Note: needs a changelog entry at release time (version TBD depending on what else ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)