### PR TITLE
expose: fix loopback redirects + stream large responses

### DIFF
--- a/cloudflare/src/session.ts
+++ b/cloudflare/src/session.ts
@@ -22,9 +22,14 @@ export class SessionRoom {
   // pendingTunnelReqs lives in DO instance memory; a request keeps the
   // DO awake until it resolves or times out, so the map never has to
   // survive hibernation.
+  // A tunnel response is one or more `tunnel_resp` chunks. The head chunk
+  // carries status + headers and resolves the request (with a whole-buffer body
+  // for a single chunk, or a ReadableStream for a multi-chunk one); later chunks
+  // enqueue into that stream's controller until one arrives with more=false.
   private pendingTunnelReqs: Map<string, {
-    resolve: (resp: { status: number; headers: Record<string, string>; body: Uint8Array }) => void;
+    resolve: (resp: { status: number; headers: Record<string, string>; body: ReadableStream<Uint8Array> | Uint8Array }) => void;
     timeout: ReturnType<typeof setTimeout>;
+    controller?: ReadableStreamDefaultController<Uint8Array>; // set once a multi-chunk (streamed) response begins
   }> = new Map();
 
   constructor(state: DurableObjectState) {
@@ -194,15 +199,22 @@ export class SessionRoom {
         }));
       }
     } else if (attachment.role === "tunnel") {
-      // Fail any in-flight tunnel requests so visitors get a clear 503
-      // rather than hanging until the per-request timeout.
+      // Fail any in-flight tunnel requests so visitors get a clear signal
+      // rather than hanging until the per-request timeout. A request already
+      // streaming (controller set) can't change its status any more — its
+      // Response headers are on the wire — so end its body with an error;
+      // one still awaiting its head resolves to a 502.
       for (const [, entry] of this.pendingTunnelReqs) {
         clearTimeout(entry.timeout);
-        entry.resolve({
-          status: 502,
-          headers: { "Content-Type": "text/plain" },
-          body: new TextEncoder().encode("reminal: tunnel disconnected\n"),
-        });
+        if (entry.controller) {
+          try { entry.controller.error(new Error("reminal: tunnel disconnected")); } catch { /* already closed */ }
+        } else {
+          entry.resolve({
+            status: 502,
+            headers: { "Content-Type": "text/plain" },
+            body: new TextEncoder().encode("reminal: tunnel disconnected\n"),
+          });
+        }
       }
       this.pendingTunnelReqs.clear();
       await this.state.storage.setAlarm(Date.now() + ORPHAN_TTL_MS);
@@ -380,15 +392,62 @@ export class SessionRoom {
     if (!reqID) return;
     const entry = this.pendingTunnelReqs.get(reqID);
     if (!entry) return;
-    clearTimeout(entry.timeout);
-    this.pendingTunnelReqs.delete(reqID);
 
-    const body = typeof resp.body === "string" ? base64ToBytes(resp.body) : new Uint8Array();
-    entry.resolve({
-      status: typeof resp.status === "number" ? resp.status : 502,
-      headers: resp.headers ?? {},
-      body,
+    const chunk = typeof resp.body === "string" ? base64ToBytes(resp.body) : new Uint8Array();
+    const more = resp.more === true;
+
+    // Idle watchdog: a stalled stream mustn't pin the DO. Re-armed per chunk.
+    const armStall = () => {
+      entry.timeout = setTimeout(() => {
+        try { entry.controller?.error(new Error("reminal: tunnel stream stalled")); } catch { /* already closed */ }
+        this.pendingTunnelReqs.delete(reqID);
+      }, TUNNEL_REQ_TIMEOUT_MS);
+    };
+
+    // Continuation chunk of an already-streaming response.
+    if (entry.controller) {
+      clearTimeout(entry.timeout);
+      if (chunk.length) {
+        try { entry.controller.enqueue(chunk); } catch { /* visitor cancelled the read */ }
+      }
+      if (more) {
+        armStall();
+      } else {
+        try { entry.controller.close(); } catch { /* already closed/cancelled */ }
+        this.pendingTunnelReqs.delete(reqID);
+      }
+      return;
+    }
+
+    // Head chunk — carries status + headers.
+    clearTimeout(entry.timeout);
+    const status = typeof resp.status === "number" ? resp.status : 502;
+    const headers: Record<string, string> = resp.headers ?? {};
+
+    if (!more) {
+      // Single-chunk response (small body, or an older single-message agent).
+      this.pendingTunnelReqs.delete(reqID);
+      entry.resolve({ status, headers, body: chunk });
+      return;
+    }
+
+    // Multi-chunk: open a stream, hand the Response back now, keep enqueuing as
+    // later chunks arrive. Keep the entry in the map (with its controller) until
+    // a chunk with more=false closes it.
+    const stream = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        if (chunk.length) controller.enqueue(chunk);
+        entry.controller = controller;
+      },
+      cancel: () => {
+        // Visitor aborted the download; stop tracking it. The agent stops when
+        // its next WS write is dropped.
+        clearTimeout(entry.timeout);
+        this.pendingTunnelReqs.delete(reqID);
+      },
     });
+    armStall();
+    entry.resolve({ status, headers, body: stream });
   }
 
   // ---- tunnel: HTTP proxy ----
@@ -453,7 +512,7 @@ export class SessionRoom {
       headers[k] = v;
     });
 
-    const promise = new Promise<{ status: number; headers: Record<string, string>; body: Uint8Array }>((resolve) => {
+    const promise = new Promise<{ status: number; headers: Record<string, string>; body: ReadableStream<Uint8Array> | Uint8Array }>((resolve) => {
       const timeout = setTimeout(() => {
         this.pendingTunnelReqs.delete(reqID);
         resolve({

--- a/cloudflare/src/session.ts
+++ b/cloudflare/src/session.ts
@@ -478,17 +478,29 @@ export class SessionRoom {
 
     const out = await promise;
 
-    // Rewrite absolute-path redirects so they stay under /p/<id>/.
-    // Upstream apps don't know we're behind a prefix, so they emit
-    // headers like `Location: /folder/` which the browser would otherwise
-    // resolve to the relay root (404). Path-relative + absolute-URL
-    // redirects are passed through unchanged.
+    // Rewrite redirects so they stay under /p/<id>/. Upstream apps don't know
+    // we're behind a prefix (and see their own Host as 127.0.0.1:<port>), so
+    // they emit Location headers we have to fix:
+    //   - absolute-PATH ("/folder/") — the browser would resolve it to the
+    //     relay root (404); re-prefix to /p/<id>/folder/.
+    //   - absolute-URL to LOOPBACK ("https://127.0.0.1:10000/x", "http://localhost/x",
+    //     "http://[::1]/x") — the app built it from the Host we handed it. The
+    //     browser would follow it to the VISITOR'S own machine; rewrite to the
+    //     public path+query under the prefix. A loopback host is unambiguously
+    //     wrong for a public tunnel, so this is always safe.
+    // Absolute URLs to any OTHER host are left alone (real off-site redirects).
     const prefix = `/p/${sessionId}`;
     for (const key of Object.keys(out.headers)) {
       if (key.toLowerCase() !== "location") continue;
       const v = out.headers[key];
-      if (v && v.startsWith("/") && !v.startsWith(prefix + "/") && !v.startsWith("//")) {
+      if (!v) continue;
+      if (v.startsWith("/") && !v.startsWith(prefix + "/") && !v.startsWith("//")) {
         out.headers[key] = prefix + v;
+        continue;
+      }
+      const loop = loopbackLocationPath(v);
+      if (loop !== null) {
+        out.headers[key] = prefix + loop;
       }
     }
 
@@ -592,6 +604,25 @@ async function hmacHex(keyHex: string, message: string): Promise<string> {
   const data = new TextEncoder().encode(message);
   const sig = await crypto.subtle.sign("HMAC", key, data.buffer as ArrayBuffer);
   return toHex(new Uint8Array(sig));
+}
+
+// loopbackLocationPath returns the path+query of a Location header value IFF it
+// is an absolute URL pointing at a loopback host — 127.0.0.0/8, localhost, or
+// ::1, any port. That's the address the tunnel agent hands the upstream as its
+// Host, so an app that builds an absolute self-redirect (canonical host / HTTPS
+// / trailing slash) emits e.g. "https://127.0.0.1:10000/x"; following it would
+// send the visitor to their OWN machine. Returns null for anything else — real
+// off-site redirects and relative/opaque values are left untouched.
+function loopbackLocationPath(loc: string): string | null {
+  let u: URL;
+  try {
+    u = new URL(loc);
+  } catch {
+    return null; // not an absolute URL (relative path handled elsewhere)
+  }
+  const h = u.hostname.toLowerCase();
+  const isLoopback = h === "localhost" || h === "::1" || h === "[::1]" || h.startsWith("127.");
+  return isLoopback ? u.pathname + u.search : null;
 }
 
 function toHex(b: Uint8Array): string {

--- a/internal/client/tunnel.go
+++ b/internal/client/tunnel.go
@@ -26,12 +26,21 @@ import (
 	"github.com/reminal/reminal/internal/session"
 )
 
-// maxTunnelBody bounds a single proxied response. Cloudflare DOs cap
-// each WS message at 1 MiB; with base64 expansion (4/3x) + headers JSON
-// + envelope, ~700 KB of raw bytes is the safe ceiling. Larger
-// responses get truncated for now — streaming-through-tunnel is a v2
-// feature.
-const maxTunnelBody = 700 * 1024
+// tunnelChunkBytes bounds ONE tunnel_resp message's raw body. Cloudflare DOs
+// cap each WS message at 1 MiB; with base64 expansion (4/3x) + headers JSON +
+// envelope, ~700 KB of raw bytes is the safe ceiling. A proxied response larger
+// than this is streamed as several tunnel_resp chunks (each carrying `more`),
+// which the relay reassembles into a streamed Response — so large images/GIFs/
+// downloads are no longer truncated at the old single-message limit.
+const tunnelChunkBytes = 700 * 1024
+
+// maxTunnelResponse caps a whole streamed response. It's an abuse guard AND a
+// memory guard: a slow visitor lets chunks queue in the relay's Durable Object
+// (which has ~128 MB), so the ceiling stays well under that. 64 MB is ~90x the
+// old single-message limit — ample for any normal page, image, GIF, or asset.
+// Past it the stream is closed cleanly (a truncated body, as before, just at a
+// far higher ceiling).
+const maxTunnelResponse = 64 * 1024 * 1024
 
 // TunnelOptions configures a port-forward agent.
 type TunnelOptions struct {
@@ -379,12 +388,6 @@ func (t *Tunnel) handleTunnelReq(conn *websocket.Conn, payload string) {
 	}
 	defer resp.Body.Close()
 
-	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxTunnelBody))
-	if err != nil {
-		t.sendError(conn, req.ReqID, fmt.Sprintf("read response: %v", err))
-		return
-	}
-
 	headers := map[string]string{}
 	for k, v := range resp.Header {
 		if isHopHeader(k) || len(v) == 0 {
@@ -393,13 +396,61 @@ func (t *Tunnel) handleTunnelReq(conn *websocket.Conn, payload string) {
 		headers[k] = v[0]
 	}
 
-	out, _ := json.Marshal(map[string]any{
-		"req_id":  req.ReqID,
-		"status":  resp.StatusCode,
-		"headers": headers,
-		"body":    base64.StdEncoding.EncodeToString(respBody),
-	})
-	_ = t.writeMsg(conn, protocol.Message{Type: protocol.TypeTunnelResp, Data: string(out)})
+	// Stream the body as one or more tunnel_resp chunks. The FIRST chunk carries
+	// status + headers; every chunk carries `more` (true = another follows). The
+	// relay hands the visitor a streamed Response and enqueues each chunk as it
+	// arrives, so a large body is no longer capped at one 1-MiB WS message. A
+	// single-chunk body (the common case) is one message with more=false, which
+	// an older relay still treats as a whole response.
+	buf := make([]byte, tunnelChunkBytes)
+	var total int64
+	firstSent := false
+	send := func(chunk []byte, more bool) error {
+		payload := map[string]any{
+			"req_id": req.ReqID,
+			"body":   base64.StdEncoding.EncodeToString(chunk),
+			"more":   more,
+		}
+		if !firstSent {
+			payload["status"] = resp.StatusCode
+			payload["headers"] = headers
+			firstSent = true
+		}
+		out, _ := json.Marshal(payload)
+		return t.writeMsg(conn, protocol.Message{Type: protocol.TypeTunnelResp, Data: string(out)})
+	}
+	for {
+		n, rerr := io.ReadFull(resp.Body, buf)
+		total += int64(n)
+		capped := total >= maxTunnelResponse
+		switch {
+		case rerr == nil:
+			// Filled the buffer — more data may follow (or an exact-boundary EOF
+			// next read). Stop early if we've hit the abuse cap.
+			if err := send(buf[:n], !capped); err != nil || capped {
+				return
+			}
+		case rerr == io.ErrUnexpectedEOF:
+			// Final, partial chunk.
+			_ = send(buf[:n], false)
+			return
+		case rerr == io.EOF:
+			// EOF exactly on a chunk boundary (or an empty body): nothing more to
+			// send, so close the stream. firstSent stays false only for a
+			// zero-length body — send an empty final chunk so status+headers go out.
+			_ = send(nil, false)
+			return
+		default:
+			// Mid-stream read error. If we've already sent the head we can only
+			// end the stream; otherwise surface a clean error to the visitor.
+			if firstSent {
+				_ = send(nil, false)
+			} else {
+				t.sendError(conn, req.ReqID, fmt.Sprintf("read response: %v", rerr))
+			}
+			return
+		}
+	}
 }
 
 func (t *Tunnel) sendError(conn *websocket.Conn, reqID, msg string) {


### PR DESCRIPTION
Two `reminal expose` fixes (reported on GitHub).

**1. Loopback redirects sent visitors to their own machine.** A tunneled app sees its Host as `127.0.0.1:<port>` and emits absolute self-redirects like `Location: https://127.0.0.1:10000/`; the Worker only re-prefixed absolute-*path* redirects, so these passed through and the browser followed them to its own localhost. The Worker now rewrites loopback absolute-URL `Location` headers (127.0.0.0/8, localhost, ::1 — any port) to `/p/<id>/…`. Off-site redirects untouched.

**2. Large images/GIFs/downloads were truncated at ~700 KB.** The whole response was one WS message (DO cap 1 MiB), so the agent read only the first ~700 KB and dropped the rest. Now the agent **streams** the body as chunks (each ≤700 KB, `more` flag), and the Worker returns a `ReadableStream` Response that enqueues chunks as they arrive. Bounded by a 64 MB guard (DO memory). Backward-compatible both directions; idle watchdog + disconnect-errors-streams for robustness.

**Verified** end-to-end with `wrangler dev` (the real Worker) + the fixed agent: loopback `Location` rewritten to `/p/<id>/…`; 5 MB, exact 2-chunk-boundary, and small files all round-trip with identical SHA-256. Worker `tsc` clean; Go vet/gofmt/test/race + cross-compile green.

Note: needs a `wrangler deploy` (Worker change) **and** a binary release (agent change) to take effect; changelog entry at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)