### PR TITLE
linux: capture the Wayland desktop instead of a black X11 root

### DIFF
--- a/internal/client/waylandcapture.go
+++ b/internal/client/waylandcapture.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Harshal Gajjar
+
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/jpeg"
+	_ "image/png" // register the PNG decoder for the screenshot tools' output
+	"os"
+	"strings"
+)
+
+// Wayland screen capture.
+//
+// The X11 path (`import -window root`) returns a BLACK frame on Wayland: the
+// compositor doesn't expose the desktop to X11 clients, so grabbing Xwayland's
+// root captures nothing. Wayland instead requires a compositor-blessed
+// screenshot path, which differs per desktop — so we shell out to whichever of
+// these is present, newest-first by how universal it is:
+//
+//	grim              wlroots (Sway, Hyprland) — PNG to stdout, supports regions
+//	gnome-screenshot  GNOME / Cinnamon (Linux Mint) — whole screen to a file
+//	spectacle         KDE Plasma — whole screen to a file
+//
+// The tool returns a full-screen (or, for grim, a region) PNG; we decode it,
+// crop to the requested rectangle if the tool couldn't, downscale, and
+// re-encode JPEG — the same shape the X11 path produces, so the rest of the
+// mirror pipeline is unchanged. Whichever tool runs may make the compositor show
+// a one-time "share your screen?" consent prompt on the host (Wayland's model);
+// that's expected and out of our control.
+
+// isWaylandSession reports whether this login session is Wayland. XDG_SESSION_TYPE
+// is the canonical signal and is set even when Xwayland also set DISPLAY (the
+// common case on GNOME/Cinnamon), which is exactly where the old "DISPLAY empty"
+// check missed Wayland and let the X11 path capture a black root.
+func isWaylandSession() bool {
+	if strings.EqualFold(os.Getenv("XDG_SESSION_TYPE"), "wayland") {
+		return true
+	}
+	return os.Getenv("WAYLAND_DISPLAY") != ""
+}
+
+// waylandShotTool returns the name of the first available Wayland screenshot
+// tool, or "" if none is installed.
+func waylandShotTool() string {
+	for _, t := range []string{"grim", "gnome-screenshot", "spectacle"} {
+		if have(t) {
+			return t
+		}
+	}
+	return ""
+}
+
+// waylandShotDeps is the human-readable install hint listing the tools we try.
+const waylandShotDeps = "grim (wlroots), gnome-screenshot (GNOME/Cinnamon), or spectacle (KDE)"
+
+// waylandGrabPNG captures the whole screen as PNG bytes with the given tool.
+// grim writes to stdout; the others only write a file, so we route through a
+// temp path and read it back.
+func waylandGrabPNG(tool string) ([]byte, error) {
+	switch tool {
+	case "grim":
+		return runRaw("grim", "-t", "png", "-")
+	case "gnome-screenshot", "spectacle":
+		f, err := os.CreateTemp("", "reminal-wl-*.png")
+		if err != nil {
+			return nil, err
+		}
+		path := f.Name()
+		_ = f.Close()
+		defer os.Remove(path)
+		var runErr error
+		if tool == "gnome-screenshot" {
+			_, runErr = run("gnome-screenshot", "-f", path)
+		} else {
+			// -b background (no GUI), -n no notification, -f fullscreen, -o file.
+			_, runErr = run("spectacle", "-b", "-n", "-f", "-o", path)
+		}
+		if runErr != nil {
+			return nil, runErr
+		}
+		return os.ReadFile(path)
+	}
+	return nil, fmt.Errorf("no wayland screenshot tool")
+}
+
+// waylandCapture captures a region of the Wayland desktop (or the whole screen
+// when region is nil) and returns a downscaled JPEG, matching the X11 path's
+// output. A region is honored natively by grim; for the file-based tools we grab
+// the whole screen and crop it here.
+func waylandCapture(region *image.Rectangle) ([]byte, error) {
+	tool := waylandShotTool()
+	if tool == "" {
+		return nil, fmt.Errorf("no Wayland screenshot tool found — install one of: %s", waylandShotDeps)
+	}
+
+	var pngBytes []byte
+	var err error
+	if tool == "grim" && region != nil {
+		pngBytes, err = runRaw("grim", "-t", "png", "-g",
+			fmt.Sprintf("%d,%d %dx%d", region.Min.X, region.Min.Y, region.Dx(), region.Dy()), "-")
+	} else {
+		pngBytes, err = waylandGrabPNG(tool)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%s capture failed (Wayland may have denied the screen-share, or no display is attached): %w", tool, err)
+	}
+	if len(pngBytes) == 0 {
+		return nil, fmt.Errorf("%s returned an empty image — the compositor likely denied screen capture", tool)
+	}
+
+	img, _, err := image.Decode(bytes.NewReader(pngBytes))
+	if err != nil {
+		return nil, fmt.Errorf("decode %s output: %w", tool, err)
+	}
+	// Crop in-process when the tool grabbed the whole screen but a sub-region was
+	// asked for (grim already cropped). Clamp to the image bounds so a stale
+	// geometry can't panic.
+	if region != nil && !(tool == "grim") {
+		r := region.Intersect(img.Bounds())
+		if !r.Empty() {
+			if sub, ok := img.(interface {
+				SubImage(image.Rectangle) image.Image
+			}); ok {
+				img = sub.SubImage(r)
+			}
+		}
+	}
+	return downscaleJPEG(img, winMaxWidth, 55)
+}
+
+// downscaleJPEG box-averages src down to fit within maxW (only shrinking, like
+// ImageMagick's "NxN>") and encodes JPEG at the given quality. Pure stdlib +
+// arithmetic so it needs no image dependency and runs on every platform.
+func downscaleJPEG(src image.Image, maxW, quality int) ([]byte, error) {
+	b := src.Bounds()
+	sw, sh := b.Dx(), b.Dy()
+	if sw <= 0 || sh <= 0 {
+		return nil, fmt.Errorf("empty image")
+	}
+	dw, dh := sw, sh
+	if sw > maxW {
+		dw = maxW
+		dh = sh * maxW / sw
+		if dh < 1 {
+			dh = 1
+		}
+	}
+	dst := image.NewRGBA(image.Rect(0, 0, dw, dh))
+	for dy := 0; dy < dh; dy++ {
+		sy0, sy1 := b.Min.Y+dy*sh/dh, b.Min.Y+(dy+1)*sh/dh
+		if sy1 <= sy0 {
+			sy1 = sy0 + 1
+		}
+		for dx := 0; dx < dw; dx++ {
+			sx0, sx1 := b.Min.X+dx*sw/dw, b.Min.X+(dx+1)*sw/dw
+			if sx1 <= sx0 {
+				sx1 = sx0 + 1
+			}
+			var rr, gg, bb, n uint32
+			for y := sy0; y < sy1; y++ {
+				for x := sx0; x < sx1; x++ {
+					r, g, bl, _ := src.At(x, y).RGBA() // 16-bit per channel
+					rr += r >> 8
+					gg += g >> 8
+					bb += bl >> 8
+					n++
+				}
+			}
+			if n == 0 {
+				n = 1
+			}
+			o := dy*dst.Stride + dx*4
+			dst.Pix[o] = byte(rr / n)
+			dst.Pix[o+1] = byte(gg / n)
+			dst.Pix[o+2] = byte(bb / n)
+			dst.Pix[o+3] = 0xFF
+		}
+	}
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, dst, &jpeg.Options{Quality: quality}); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// waylandScreenSize returns the desktop dimensions by taking one screenshot and
+// reading its bounds — used to build the "display:0" entry when there's no
+// Xwayland root to measure (a pure-Wayland session). Best-effort.
+func waylandScreenSize() (w, h int, ok bool) {
+	tool := waylandShotTool()
+	if tool == "" {
+		return 0, 0, false
+	}
+	pngBytes, err := waylandGrabPNG(tool)
+	if err != nil || len(pngBytes) == 0 {
+		return 0, 0, false
+	}
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(pngBytes))
+	if err != nil {
+		return 0, 0, false
+	}
+	return cfg.Width, cfg.Height, true
+}

--- a/internal/client/waylandcapture_test.go
+++ b/internal/client/waylandcapture_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Harshal Gajjar
+
+package client
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"testing"
+)
+
+// TestIsWaylandSession pins the detection that decides X11-vs-Wayland capture.
+// The bug this fixes: the old check only saw Wayland when DISPLAY was empty, so
+// a Wayland session with Xwayland (DISPLAY set — the common GNOME/Cinnamon case)
+// slipped through to the X11 path and captured a black root.
+func TestIsWaylandSession(t *testing.T) {
+	cases := []struct {
+		name, sessionType, waylandDisplay, display string
+		want                                       bool
+	}{
+		{"x11 only", "x11", "", ":0", false},
+		{"headless", "", "", "", false},
+		{"wayland via session type (Xwayland also set)", "wayland", "wayland-0", ":0", true},
+		{"wayland via WAYLAND_DISPLAY only", "", "wayland-0", "", true},
+		{"session type wins even with DISPLAY set", "wayland", "", ":0", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("XDG_SESSION_TYPE", c.sessionType)
+			t.Setenv("WAYLAND_DISPLAY", c.waylandDisplay)
+			t.Setenv("DISPLAY", c.display)
+			if got := isWaylandSession(); got != c.want {
+				t.Errorf("isWaylandSession()=%v want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestDownscaleJPEG covers the shared decode→shrink→JPEG step the Wayland path
+// uses in place of ImageMagick: it must only shrink (never enlarge), preserve
+// aspect, produce a decodable JPEG, and keep the image's colour (not go black).
+func TestDownscaleJPEG(t *testing.T) {
+	// 800x400 solid mid-blue, offset origin to catch bounds-handling bugs.
+	src := image.NewRGBA(image.Rect(10, 20, 810, 420))
+	blue := color.RGBA{0x22, 0x88, 0xff, 0xff}
+	for y := src.Rect.Min.Y; y < src.Rect.Max.Y; y++ {
+		for x := src.Rect.Min.X; x < src.Rect.Max.X; x++ {
+			src.SetRGBA(x, y, blue)
+		}
+	}
+
+	// Downscale to fit 200 wide → expect 200x100.
+	jpg, err := downscaleJPEG(src, 200, 55)
+	if err != nil {
+		t.Fatalf("downscaleJPEG: %v", err)
+	}
+	img, err := jpeg.Decode(bytes.NewReader(jpg))
+	if err != nil {
+		t.Fatalf("output not valid JPEG: %v", err)
+	}
+	if got := img.Bounds().Dx(); got != 200 {
+		t.Errorf("width=%d want 200", got)
+	}
+	if got := img.Bounds().Dy(); got != 100 {
+		t.Errorf("height=%d want 100 (aspect preserved)", got)
+	}
+	// Centre pixel should be ~blue, not black.
+	r, g, b, _ := img.At(100, 50).RGBA()
+	if r>>8 > 0x60 || g>>8 < 0x50 || b>>8 < 0xB0 {
+		t.Errorf("centre colour drifted: r=%d g=%d b=%d (want ~ 0x22,0x88,0xff)", r>>8, g>>8, b>>8)
+	}
+
+	// Smaller-than-max must NOT be enlarged.
+	jpg2, err := downscaleJPEG(src, 4000, 55)
+	if err != nil {
+		t.Fatalf("downscaleJPEG (no shrink): %v", err)
+	}
+	img2, _ := jpeg.Decode(bytes.NewReader(jpg2))
+	if img2.Bounds().Dx() != 800 {
+		t.Errorf("width=%d want 800 (should not enlarge)", img2.Bounds().Dx())
+	}
+}

--- a/internal/client/windows_backends.go
+++ b/internal/client/windows_backends.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"fmt"
+	"image"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -679,14 +680,21 @@ func asStr(s string) string {
 type linuxWindows struct{}
 
 func (linuxWindows) unsupported() string {
-	// Headless first. With no display of either kind — a cloud VM, a plain SSH
-	// box — the old code fell through to "install wmctrl", sending people after
+	// Headless first. With no display of any kind — a cloud VM, a plain SSH box
+	// — the old code fell through to "install wmctrl", sending people after
 	// packages that cannot help because there is no desktop to mirror at all.
-	if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
+	if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" && !isWaylandSession() {
 		return "no desktop session on this host — window mirroring needs a graphical login; the terminal works as normal"
 	}
-	if os.Getenv("WAYLAND_DISPLAY") != "" && os.Getenv("DISPLAY") == "" {
-		return "Wayland isn't supported yet — X11 (or Xwayland) required for window mirroring"
+	// Wayland: capture goes through a compositor screenshot tool (see
+	// waylandcapture.go). Only the full-desktop view is supported so far. If no
+	// tool is installed, say exactly that — the old code let the X11 path run and
+	// stream a BLACK frame here, because Xwayland's root has no desktop content.
+	if isWaylandSession() {
+		if waylandShotTool() == "" {
+			return "Wayland desktop view needs a screenshot tool — install one of: " + waylandShotDeps + ", or log in to an Xorg session"
+		}
+		return ""
 	}
 	if !have("wmctrl") {
 		return "install wmctrl (and xdotool + imagemagick + x11-utils) to mirror windows on Linux"
@@ -694,16 +702,31 @@ func (linuxWindows) unsupported() string {
 	return ""
 }
 
-// permissionHint has no analogue on X11 — there's no per-app screen-capture
-// permission, so if the tools are present, capture works.
-func (linuxWindows) permissionHint() string { return "" }
+// permissionHint surfaces a one-line caveat to the viewer. On X11 there's no
+// per-app screen-capture permission, so it's silent. On Wayland it sets
+// expectations: the desktop view works via a screenshot tool, but per-window
+// mirroring and input injection have no portable Wayland path yet, and the
+// compositor may prompt once to allow screen sharing.
+func (linuxWindows) permissionHint() string {
+	if isWaylandSession() {
+		return "Wayland: the full-desktop view works, but per-window mirroring and click/keyboard control aren't supported here yet — and the host may prompt once to allow screen sharing."
+	}
+	return ""
+}
 
 func (linuxWindows) list() ([]winInfo, error) {
 	// -l list, -G geometry, -x include WM_CLASS. Columns:
 	//   id desktop wm_class x y w h host title...
 	out, err := run("wmctrl", "-lGx")
 	if err != nil {
-		return nil, err
+		// A pure Wayland session (no Xwayland) has no wmctrl window list, but the
+		// desktop is still capturable via the screenshot path — carry on with no
+		// X windows and let the display:0 entry below make "View full desktop"
+		// available. On X11, a wmctrl failure is still a hard error.
+		if !isWaylandSession() {
+			return nil, err
+		}
+		out = ""
 	}
 	var wins []winInfo
 	for _, line := range strings.Split(out, "\n") {
@@ -755,7 +778,14 @@ func (linuxWindows) list() ([]winInfo, error) {
 	// One entry, not one per monitor: X11 composites every output into a single
 	// root framebuffer, and `import -window root` captures precisely that. Its
 	// origin is the root's own, so click mapping needs no special case.
-	if x, y, sw, sh, ok := xrootGeom(); ok && sw >= 40 && sh >= 40 {
+	x, y, sw, sh, ok := xrootGeom()
+	if !ok && isWaylandSession() {
+		// No Xwayland root to measure — size the desktop from one screenshot.
+		if w, h, wok := waylandScreenSize(); wok {
+			x, y, sw, sh, ok = 0, 0, w, h, true
+		}
+	}
+	if ok && sw >= 40 && sh >= 40 {
 		wins = append(wins, winInfo{
 			ID:    "display:0",
 			App:   "Desktop",
@@ -890,6 +920,16 @@ func xpropExtents(id, atom string) (left, right, top, bottom int, ok bool) {
 }
 
 func (linuxWindows) capture(w winInfo) ([]byte, error) {
+	// Wayland: X11 root/window grabs come back black (see waylandcapture.go).
+	// Capture via a compositor screenshot tool instead — the whole screen for
+	// the desktop, or the window's screen rectangle for a specific window.
+	if isWaylandSession() {
+		if isDisplayID(w.ID) {
+			return waylandCapture(nil)
+		}
+		r := image.Rect(w.X, w.Y, w.X+w.W, w.Y+w.H)
+		return waylandCapture(&r)
+	}
 	if !have("import") {
 		return nil, fmt.Errorf("install imagemagick (provides `import`) to capture windows")
 	}
@@ -920,6 +960,10 @@ func (linuxWindows) capture(w winInfo) ([]byte, error) {
 }
 
 func (linuxWindows) captureRegion(x, y, w, h int) ([]byte, error) {
+	if isWaylandSession() {
+		r := image.Rect(x, y, x+w, y+h)
+		return waylandCapture(&r)
+	}
 	if !have("import") {
 		return nil, fmt.Errorf("install imagemagick (provides `import`) to capture windows")
 	}


### PR DESCRIPTION
Fixes the GitHub report: viewing a Linux desktop over reminal shows a **black window** on Wayland.

**Cause:** the Linux backend captures via X11 (`import -window root`), but Wayland doesn't expose the desktop to X11 — Xwayland's root is empty. The Wayland guard also missed the common case: it only tripped when `DISPLAY` was empty, but Wayland sessions run Xwayland (so `DISPLAY` is set), and the X11 path ran and streamed black.

**Fix:**
- Detect Wayland by `XDG_SESSION_TYPE=wayland` (or `WAYLAND_DISPLAY`), regardless of Xwayland's `DISPLAY`.
- On Wayland, capture the desktop with a compositor screenshot tool — `grim` (wlroots), `gnome-screenshot` (GNOME/Cinnamon), `spectacle` (KDE) — then decode / crop / box-downscale / JPEG-encode in Go (no new deps), same frame shape as the X11 path. `list()` still surfaces a `display:0` entry.
- If no tool is installed, `unsupported()` says exactly that (with install list / "use an Xorg session") **instead of black**; `permissionHint()` tells the viewer only the desktop view works on Wayland (per-window + input have no portable Wayland path yet) and the host may prompt once for screen-share consent.

**Verified** end-to-end on a real Wayland session (headless **sway/wlroots + grim** in a VM): Wayland detected, `display:0` listed, and a valid **non-black** desktop JPEG captured. Cinnamon (the reporter's DE) uses `gnome-screenshot` via the same pipeline — reporter to confirm. Unit tests cover the detection matrix and the Go downscale/JPEG step; full suite + cross-compile green.

Note: agent-side (binary) change — no Worker/viewer change. Changelog at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)