### PR TITLE
Remote windows that feel local: peer-to-peer input + cross-platform H.264

### DIFF
--- a/cloudflare/public/index.html
+++ b/cloudflare/public/index.html
@@ -8831,6 +8831,15 @@
           ip.liveUntil = performance.now() + 1500;
           dropQueuedFrames(ip);
         }
+        // Peer-to-peer input: when the reliable input channel is up, send the
+        // event straight to the agent over DTLS instead of through the billed
+        // relay. That removes a full Durable-Object round-trip from every click
+        // and keystroke — the change that makes a remote window feel local.
+        // DTLS already protects it, so no app-layer encryption (matching frames
+        // and acks on the other channels). Any failure falls through to WS.
+        if (rtcInput && rtcInput.readyState === 'open') {
+          try { rtcInput.send(JSON.stringify(obj)); return; } catch (_) {}
+        }
       }
       if (!ws || ws.readyState !== WebSocket.OPEN || !cryptoKey) return;
       const frame = { type };
@@ -9663,6 +9672,14 @@
     // the stream, and the pane said the host was asleep. Kept separate so a
     // congested picture can never mute the conversation about it.
     let rtcCtl = null;
+    // The "input" channel: mouse/keyboard/scroll events, viewer→agent. Reliable
+    // and ordered (unlike frames/ctl), because a dropped or reordered input
+    // event leaves the remote in a wrong state — a stuck modifier, a click that
+    // lands before the focus it followed. It exists so input skips the billed WS
+    // relay: an event used to make a full round-trip through the Cloudflare
+    // Durable Object, and that hop was the single biggest reason typing and
+    // clicking felt remote. Falls back to WS whenever it isn't open.
+    let rtcInput = null;
     let rtcRetryAt = 0;  // don't (re)attempt P2P before this time (ms epoch)
     let rtcHelloAt = 0;  // when the current webrtc_hello was sent (to time out silence)
     let rtcRelayed = false; // is the P2P path going through a TURN relay (vs direct)?
@@ -9691,8 +9708,9 @@
     function teardownWebRTC() {
       try { if (rtcDc) rtcDc.close(); } catch (_) {}
       try { if (rtcCtl) rtcCtl.close(); } catch (_) {}
+      try { if (rtcInput) rtcInput.close(); } catch (_) {}
       try { if (rtcPc) rtcPc.close(); } catch (_) {}
-      rtcPc = null; rtcDc = null; rtcCtl = null; rtcPeerId = null; rtcPendingIce = []; rtcRelayed = false;
+      rtcPc = null; rtcDc = null; rtcCtl = null; rtcInput = null; rtcPeerId = null; rtcPendingIce = []; rtcRelayed = false;
     }
     function rtcCtlOpen() { return !!(rtcCtl && rtcCtl.readyState === 'open'); }
     // Inspect the live ICE candidate pair to tell a direct P2P path from a TURN
@@ -9797,6 +9815,15 @@
           };
           ch.onopen = () => { if (DEBUG) dbg('rtc ctl channel open'); };
           ch.onclose = () => { if (rtcCtl === ch) rtcCtl = null; };
+          return;
+        }
+        // The input channel carries events the other way (viewer→agent) and the
+        // agent never sends on it, so there's no onmessage — sendWin just writes
+        // window_input events here instead of the relay while it's open.
+        if (ch.label === 'input') {
+          rtcInput = ch;
+          ch.onopen = () => { if (DEBUG) dbg('rtc input channel open'); };
+          ch.onclose = () => { if (rtcInput === ch) rtcInput = null; };
           return;
         }
         rtcDc = ch;

--- a/internal/client/capture_ffmpeg.go
+++ b/internal/client/capture_ffmpeg.go
@@ -1,0 +1,525 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Harshal Gajjar
+
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// itoa is a local shorthand for the ffmpeg argument list below.
+func itoa(n int) string { return strconv.Itoa(n) }
+
+// H.264 for Windows and Linux, via ffmpeg. macOS captures and encodes in the
+// native reminal-capture helper (ScreenCaptureKit + VideoToolbox); the other
+// platforms have no such helper, so their window mirror was plain JPEG — ~15-40
+// Mbps where H.264 needs ~2, which made a smooth remote window impossible on any
+// real link. This closes that gap without a second native codebase: frames are
+// captured in Go (the same GDI / X11 grab the JPEG path already uses) and piped
+// through ffmpeg, which reaches the platform's hardware encoder — Media
+// Foundation (h264_mf) on Windows, VAAPI (h264_vaapi) on Linux — or falls back
+// to libx264 in software. ffmpeg's Annex-B output is re-framed into the exact
+// [len][flag][Annex-B AU] shape the macOS helper emits, so the winHelper
+// consumer, the DataChannel transport and the viewer's WebCodecs decoder need no
+// changes at all: to everything downstream this is just another H.264 helper.
+
+// rawCapturer is a windowBackend that can hand back one frame as tightly-packed
+// RGBA at an exact size — the input ffmpeg's rawvideo demuxer needs. The Win32
+// and X11 backends implement it; a backend that doesn't simply gets no ffmpeg
+// helper and stays on JPEG.
+type rawCapturer interface {
+	// captureRaw returns exactly tw*th*4 bytes of RGBA for window w, scaled to
+	// tw×th (forced to that exact size — a resized window renders distorted until
+	// the stream restarts the helper, never a byte-count mismatch that would
+	// desync ffmpeg's fixed-size input).
+	captureRaw(w winInfo, tw, th int) ([]byte, error)
+}
+
+// ffmpegAvailable reports whether an ffmpeg the helper can drive is on PATH. Its
+// absence is why startFFmpegHelper returns an error the stream reads as "no
+// H.264 here" and quietly keeps serving JPEG.
+func ffmpegAvailable() bool { return have("ffmpeg") || os.Getenv("REMINAL_FFMPEG") != "" }
+
+// ffmpegPath is the ffmpeg binary to run: an explicit override first (handy for
+// a bundled copy), else PATH.
+func ffmpegPath() string {
+	if p := strings.TrimSpace(os.Getenv("REMINAL_FFMPEG")); p != "" {
+		return p
+	}
+	return "ffmpeg"
+}
+
+// evenDown rounds down to an even number (>=2). H.264 4:2:0 needs even
+// dimensions, and the encoder rejects odd ones.
+func evenDown(n int) int {
+	if n < 2 {
+		return 2
+	}
+	return n &^ 1
+}
+
+// ffmpegTargetDims scales a window's content size down so its longer side is at
+// most maxWidth, preserving aspect and forcing even dimensions. The result is
+// fixed for the helper's life; a resize is handled by the stream restarting it.
+func ffmpegTargetDims(w winInfo, maxWidth int) (tw, th int) {
+	cw, ch := w.W, w.H
+	if cw <= 0 || ch <= 0 {
+		cw, ch = maxWidth, maxWidth*9/16 // last-ditch default; a real capture corrects it
+	}
+	if maxWidth <= 0 {
+		maxWidth = 1100
+	}
+	scale := 1.0
+	longer := cw
+	if ch > longer {
+		longer = ch
+	}
+	if longer > maxWidth {
+		scale = float64(maxWidth) / float64(longer)
+	}
+	return evenDown(int(float64(cw) * scale)), evenDown(int(float64(ch) * scale))
+}
+
+// ffmpegBitrate mirrors the macOS helper's budget: ~0.074 bits per pixel-frame
+// at 30fps (measured 1.7 Mbps for a full-motion 1100×700 window), scaled
+// sublinearly with frame rate — extra frames on temporally-compressed video are
+// far cheaper than linear — and clamped to a sane band.
+func ffmpegBitrate(tw, th, fps int) int {
+	if fps <= 0 {
+		fps = 30
+	}
+	base := float64(tw*th) * 2.2 * math.Pow(float64(fps)/30.0, 0.6)
+	br := int(base)
+	if br < 600_000 {
+		br = 600_000
+	}
+	if br > 12_000_000 {
+		br = 12_000_000
+	}
+	return br
+}
+
+// h264Encoder picks the H.264 encoder ffmpeg should use. Hardware first — Media
+// Foundation on Windows, VAAPI on Linux — because software x264 at these sizes
+// can cost more CPU than the rest of the agent combined; libx264 is the portable
+// fallback that a full ffmpeg always has. REMINAL_FFMPEG_ENCODER overrides the
+// choice (e.g. to force libx264 when a flaky VAAPI stack keeps failing).
+func h264Encoder(goos string) (name string, encodeArgs []string, ok bool) {
+	if forced := strings.TrimSpace(os.Getenv("REMINAL_FFMPEG_ENCODER")); forced != "" {
+		return forced, encoderArgs(forced), true
+	}
+	list := ffmpegEncoders()
+	var prefer []string
+	switch goos {
+	case "windows":
+		prefer = []string{"h264_mf", "libx264", "h264_qsv", "h264_nvenc"}
+	case "linux":
+		// libx264 before VAAPI by default: VAAPI needs a working /dev/dri render
+		// node and the hwupload filter chain, which is often absent on servers
+		// and headless boxes, and a failed hardware init just stalls the mirror.
+		// A box that has VAAPI set up can force it with REMINAL_FFMPEG_ENCODER.
+		prefer = []string{"libx264", "h264_vaapi", "h264_nvenc"}
+	default:
+		prefer = []string{"libx264"}
+	}
+	for _, e := range prefer {
+		if list[e] {
+			return e, encoderArgs(e), true
+		}
+	}
+	// Nothing we recognise — but ffmpeg without libx264 is unusual, so try it
+	// blind rather than refuse; a start failure falls back to JPEG anyway.
+	return "libx264", encoderArgs("libx264"), true
+}
+
+// encoderArgs returns the low-latency tuning for one encoder. The common goal is
+// no B-frames, no lookahead, and small, frequent keyframes so a viewer that
+// joins or drops a frame recovers within about a second.
+func encoderArgs(enc string) []string {
+	switch enc {
+	case "libx264":
+		// superfast, NOT ultrafast: ultrafast forces CAVLC, which downgrades the
+		// stream to Constrained Baseline even with -profile:v main, so it would
+		// not match the Main profile the viewer declares (avc1.4d0028) or the
+		// macOS VideoToolbox path. superfast keeps CABAC → real Main, at a small
+		// CPU cost. zerolatency drops B-frames and lookahead; level is left to
+		// the encoder (the viewer decodes from the in-band SPS regardless).
+		return []string{"-preset", "superfast", "-tune", "zerolatency",
+			"-profile:v", "main", "-x264-params", "sliced-threads=0:sync-lookahead=0:rc-lookahead=0:bframes=0"}
+	case "h264_mf":
+		// Media Foundation. Do NOT pass -profile:v main: h264_mf's profile
+		// option is not a named-constant enum (ffmpeg reports "Unable to parse
+		// profile option value main" and fails to open the encoder), so we let
+		// MF choose the profile. The viewer decodes from the in-band SPS
+		// regardless of the avc1.4d0028 it declares, so this still plays. No
+		// -hw_encoding either: forcing it fails on a box with no hardware MFT
+		// (a VM, a headless server); MF uses hardware automatically when present.
+		return nil
+	case "h264_vaapi":
+		return []string{"-profile:v", "main"}
+	case "h264_qsv":
+		return []string{"-preset", "veryfast", "-profile:v", "main"}
+	case "h264_nvenc":
+		return []string{"-preset", "p1", "-tune", "ll", "-profile:v", "main", "-bf", "0"}
+	default:
+		return []string{"-profile:v", "main"}
+	}
+}
+
+// ffmpegEncoders returns the set of H.264 encoder names this ffmpeg has, parsed
+// from `ffmpeg -encoders`. Empty on any error (the caller then tries libx264
+// blind).
+func ffmpegEncoders() map[string]bool {
+	out := map[string]bool{}
+	cmd := exec.Command(ffmpegPath(), "-hide_banner", "-encoders")
+	b, err := cmd.Output()
+	if err != nil {
+		return out
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		// Lines look like " V....D h264_vaapi   H.264/AVC (VAAPI)". The encoder
+		// name is the second whitespace field.
+		f := strings.Fields(line)
+		if len(f) >= 2 && strings.HasPrefix(f[1], "h264") || (len(f) >= 2 && f[1] == "libx264") {
+			out[f[1]] = true
+		}
+	}
+	return out
+}
+
+// startFFmpegHelper captures window w in Go and encodes it to H.264 through
+// ffmpeg, delivering frames as the same [len][flag][AU] stream startWinHelper
+// produces on macOS. Returns an error (→ the stream falls back to JPEG) if the
+// backend can't hand back raw frames, ffmpeg is missing, the first capture
+// fails, or the encoder dies inside the startup grace.
+func startFFmpegHelper(b windowBackend, w winInfo, maxWidth, quality, fps int) (*winHelper, error) {
+	rc, ok := b.(rawCapturer)
+	if !ok {
+		return nil, errors.New("backend cannot capture raw frames for ffmpeg")
+	}
+	if !ffmpegAvailable() {
+		return nil, errors.New("ffmpeg not found — install it for H.264 (JPEG mirror still works)")
+	}
+	if fps <= 0 {
+		fps = winHelperFPS
+	}
+	tw, th := ffmpegTargetDims(w, maxWidth)
+
+	// Prove capture works and the dimensions are right before spending an ffmpeg
+	// process on it: a first frame that fails is exactly the closed-window /
+	// no-permission case the stream must see as an error, not a black video.
+	first, err := rc.captureRaw(w, tw, th)
+	if err != nil {
+		return nil, fmt.Errorf("initial capture: %w", err)
+	}
+	if want := tw * th * 4; len(first) != want {
+		return nil, fmt.Errorf("capture returned %d bytes, want %d for %dx%d RGBA", len(first), want, tw, th)
+	}
+
+	enc, encArgs, _ := h264Encoder(runtime.GOOS)
+	bitrate := ffmpegBitrate(tw, th, fps)
+	// One keyframe per second bounds recovery: ffmpeg cannot be told to emit an
+	// IDR on demand through a raw pipe, so a viewer that joins mid-stream or
+	// loses a frame waits at most this long for a self-contained entry point
+	// (keyFn is therefore a no-op — see below). It is the same "bounded
+	// staleness" contract the queue overflow path already relies on.
+	keyint := fps
+	if keyint < 1 {
+		keyint = 1
+	}
+	args := []string{
+		"-hide_banner", "-loglevel", "error",
+		"-f", "rawvideo", "-pix_fmt", "rgba", "-s", fmt.Sprintf("%dx%d", tw, th), "-r", itoa(fps), "-i", "-",
+		"-an",
+		"-c:v", enc,
+	}
+	args = append(args, encArgs...)
+	args = append(args,
+		"-pix_fmt", "yuv420p",
+		"-g", itoa(keyint), "-keyint_min", itoa(keyint),
+		"-force_key_frames", "expr:gte(t,n_forced*1)",
+		"-b:v", itoa(bitrate), "-maxrate", itoa(bitrate), "-bufsize", itoa(bitrate/2),
+		"-flush_packets", "1",
+		"-f", "h264", "-",
+	)
+
+	cmd := exec.Command(ffmpegPath(), args...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, err
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("start ffmpeg: %w", err)
+	}
+
+	h := &winHelper{
+		cmd:    cmd,
+		codec:  "h264",
+		sig:    make(chan struct{}, 1),
+		dead:   make(chan struct{}),
+		stderr: &stderr,
+	}
+
+	// The framed pipe the consumer reads: the splitter turns ffmpeg's raw
+	// Annex-B stream into [len][flag][AU] messages and writes them here;
+	// readLoop reads them exactly as it does the macOS helper's stdout.
+	pr, pw := io.Pipe()
+	stop := make(chan struct{})
+	var stopOnce sync.Once
+	closeStop := func() { stopOnce.Do(func() { close(stop) }) }
+
+	h.stopFn = func() {
+		closeStop()             // tell the capture goroutine to stop
+		_ = stdin.Close()       // EOF to ffmpeg → it flushes and exits
+		if cmd.Process != nil { // backstop if it doesn't
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+		_ = pw.CloseWithError(io.EOF) // unblock readLoop → close(dead)
+	}
+	// ffmpeg gets no on-demand IDR through a raw-pixel pipe; the 1s keyint above
+	// is the recovery bound instead, so a keyframe request is a no-op here.
+	h.keyFn = func() {}
+
+	// Capture goroutine: paced grabs into ffmpeg's stdin. The first frame is
+	// already in hand, so send it immediately (a viewer sees a picture without
+	// waiting a whole frame interval).
+	go ffmpegCaptureLoop(rc, w, tw, th, fps, first, stdin, stop)
+
+	// Splitter goroutine: ffmpeg's Annex-B stdout → framed AUs on the pipe.
+	go func() {
+		err := splitAnnexBToFramed(stdout, pw)
+		if err == nil {
+			err = io.EOF
+		}
+		_ = pw.CloseWithError(err) // readLoop ends; dead closes
+	}()
+
+	go h.readLoop(pr)
+
+	// Same early-death guard as startWinHelper: a bad encoder or a missing
+	// libx264 dies within a few hundred ms, and the stream must fall back to
+	// JPEG rather than show a frozen pane.
+	select {
+	case <-h.dead:
+		closeStop()
+		_ = cmd.Wait()
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = "ffmpeg exited immediately"
+		}
+		return nil, errors.New(msg)
+	case <-time.After(helperStartupGrace):
+		return h, nil
+	}
+}
+
+// ffmpegCaptureLoop feeds RGBA frames to ffmpeg's stdin at up to fps, never
+// faster. Capture is the bottleneck on the X11/GDI path (a grab can cost >60ms),
+// so this paces to a ceiling and simply runs slower when a grab is slow — the
+// encoder handles a variable real rate. It ends (closing stdin so ffmpeg exits)
+// on stop, a write failure (ffmpeg gone), or a persistent capture error.
+func ffmpegCaptureLoop(rc rawCapturer, w winInfo, tw, th, fps int, first []byte, stdin io.WriteCloser, stop <-chan struct{}) {
+	interval := time.Second / time.Duration(maxInt(fps, 1))
+	if _, err := stdin.Write(first); err != nil {
+		_ = stdin.Close()
+		return
+	}
+	want := tw * th * 4
+	fails := 0
+	for {
+		start := time.Now()
+		select {
+		case <-stop:
+			_ = stdin.Close()
+			return
+		default:
+		}
+		pix, err := rc.captureRaw(w, tw, th)
+		if err != nil || len(pix) != want {
+			// A few transient misses are normal (a grab racing a repaint);
+			// give up only after a run of them, and let ffmpeg keep the last
+			// frame on screen meanwhile.
+			fails++
+			if fails > 30 {
+				_ = stdin.Close()
+				return
+			}
+			if sleepOrStop(stop, interval) {
+				_ = stdin.Close()
+				return
+			}
+			continue
+		}
+		fails = 0
+		if _, err := stdin.Write(pix); err != nil {
+			_ = stdin.Close() // ffmpeg died; splitter will see EOF
+			return
+		}
+		if rem := interval - time.Since(start); rem > 0 {
+			if sleepOrStop(stop, rem) {
+				_ = stdin.Close()
+				return
+			}
+		}
+	}
+}
+
+// splitAnnexBToFramed reads ffmpeg's Annex-B H.264 elementary stream and writes
+// one [uint32 len][flag][AU] message per access unit — the framing winHelper's
+// readLoop expects. An access unit is grouped as the parameter sets / SEI that
+// precede a picture plus its VCL slice; it is flushed as soon as the slice's NAL
+// completes (the next start code arrives), which is minimal latency for the
+// single-slice, no-B-frame stream the encoder is configured to produce. flag is
+// flagH264Key when the AU carries an IDR slice or an SPS (a decodable entry
+// point), else flagH264Delta.
+func splitAnnexBToFramed(r io.Reader, w io.Writer) error {
+	br := bufio.NewReaderSize(r, 1<<20)
+	var pending []byte // bytes read, not yet cut at a start code
+	var au []byte      // current access unit, each NAL prefixed with 00 00 00 01
+	auKey := false
+
+	flush := func() error {
+		if len(au) == 0 {
+			return nil
+		}
+		if err := writeFramedAU(w, au, auKey); err != nil {
+			return err
+		}
+		au = au[:0]
+		auKey = false
+		return nil
+	}
+	// onNAL appends one NAL (payload without start code) to the current AU,
+	// flushing a completed AU when a picture slice ends.
+	onNAL := func(nal []byte) error {
+		if len(nal) == 0 {
+			return nil
+		}
+		t := nal[0] & 0x1f
+		au = append(au, 0, 0, 0, 1)
+		au = append(au, nal...)
+		switch {
+		case t == 5: // IDR slice → keyframe
+			auKey = true
+			return flush()
+		case t >= 1 && t <= 4: // non-IDR slice → picture end
+			return flush()
+		case t == 7: // SPS present → the AU it belongs to is an entry point
+			auKey = true
+		}
+		return nil
+	}
+
+	buf := make([]byte, 64*1024)
+	for {
+		n, rerr := br.Read(buf)
+		if n > 0 {
+			pending = append(pending, buf[:n]...)
+			// Cut every complete NAL: bytes between one start code and the next.
+			for {
+				sc, scLen := findStartCode(pending, 0)
+				if sc < 0 {
+					break
+				}
+				next, _ := findStartCode(pending, sc+scLen)
+				if next < 0 {
+					// Only a partial NAL so far; keep from this start code on.
+					if sc > 0 {
+						pending = append(pending[:0], pending[sc:]...)
+					}
+					break
+				}
+				nal := trimTrailingZeros(pending[sc+scLen : next])
+				if err := onNAL(nal); err != nil {
+					return err
+				}
+				pending = append(pending[:0], pending[next:]...)
+			}
+		}
+		if rerr != nil {
+			// Flush the last NAL still buffered, then the final AU.
+			if sc, scLen := findStartCode(pending, 0); sc >= 0 {
+				if err := onNAL(trimTrailingZeros(pending[sc+scLen:])); err != nil {
+					return err
+				}
+			}
+			if err := flush(); err != nil {
+				return err
+			}
+			if rerr == io.EOF {
+				return nil
+			}
+			return rerr
+		}
+	}
+}
+
+// writeFramedAU writes one access unit in the helper framing: a big-endian
+// uint32 length covering the flag byte and the AU, then the flag, then the AU.
+func writeFramedAU(w io.Writer, au []byte, key bool) error {
+	flag := byte(flagH264Delta)
+	if key {
+		flag = flagH264Key
+	}
+	var hdr [5]byte
+	binary.BigEndian.PutUint32(hdr[:4], uint32(len(au)+1))
+	hdr[4] = flag
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(au)
+	return err
+}
+
+// findStartCode returns the index and length (3 or 4) of the next Annex-B start
+// code (00 00 01, or 00 00 00 01) at or after off, or -1.
+func findStartCode(b []byte, off int) (idx, length int) {
+	for i := off; i+2 < len(b); i++ {
+		if b[i] == 0 && b[i+1] == 0 && b[i+2] == 1 {
+			if i > off && b[i-1] == 0 {
+				return i - 1, 4
+			}
+			return i, 3
+		}
+	}
+	return -1, 0
+}
+
+// trimTrailingZeros drops the run of 0x00 bytes an encoder may pad after a NAL
+// (they belong to the next start code, not this NAL's payload).
+func trimTrailingZeros(b []byte) []byte {
+	n := len(b)
+	for n > 0 && b[n-1] == 0 {
+		n--
+	}
+	return b[:n]
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/client/capture_ffmpeg_test.go
+++ b/internal/client/capture_ffmpeg_test.go
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Harshal Gajjar
+
+package client
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+// nal builds one NAL unit: a header byte carrying the type in its low 5 bits,
+// then arbitrary payload.
+func nal(typ byte, payload ...byte) []byte {
+	return append([]byte{typ & 0x1f}, payload...)
+}
+
+// annexB concatenates NALs into an Annex-B elementary stream (4-byte start
+// codes), the shape ffmpeg writes on stdout.
+func annexB(nals ...[]byte) []byte {
+	var b []byte
+	for _, n := range nals {
+		b = append(b, 0, 0, 0, 1)
+		b = append(b, n...)
+	}
+	return b
+}
+
+// framedAU is one message parsed back out of splitAnnexBToFramed's output.
+type framedAU struct {
+	key bool
+	au  []byte
+}
+
+func parseFramed(t *testing.T, b []byte) []framedAU {
+	t.Helper()
+	var out []framedAU
+	for len(b) > 0 {
+		if len(b) < 5 {
+			t.Fatalf("trailing %d bytes, not a full frame header", len(b))
+		}
+		n := binary.BigEndian.Uint32(b[:4])
+		if int(n)+4 > len(b) {
+			t.Fatalf("frame length %d overruns %d remaining", n, len(b)-4)
+		}
+		flag := b[4]
+		au := b[5 : 4+int(n)]
+		out = append(out, framedAU{key: flag == flagH264Key, au: append([]byte(nil), au...)})
+		b = b[4+int(n):]
+	}
+	return out
+}
+
+// The splitter groups parameter sets and SEI with the picture that follows and
+// flushes one message per access unit, marking an IDR or SPS as a keyframe. This
+// is the contract the viewer's decoder and the winHelper queue depend on.
+func TestSplitAnnexBGroupsAccessUnits(t *testing.T) {
+	sps := nal(7, 0x42, 0x00, 0x28)
+	pps := nal(8, 0xCE)
+	idr := nal(5, 0xAA, 0xBB)
+	p1 := nal(1, 0x11)
+	p2 := nal(1, 0x22)
+
+	stream := annexB(sps, pps, idr, p1, p2, sps, pps, idr)
+	var out bytes.Buffer
+	if err := splitAnnexBToFramed(bytes.NewReader(stream), &out); err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	aus := parseFramed(t, out.Bytes())
+
+	if len(aus) != 4 {
+		t.Fatalf("got %d access units, want 4 (keyframe, P, P, keyframe)", len(aus))
+	}
+	if !aus[0].key || aus[1].key || aus[2].key || !aus[3].key {
+		t.Fatalf("keyframe flags = %v %v %v %v, want true false false true",
+			aus[0].key, aus[1].key, aus[2].key, aus[3].key)
+	}
+	// The first AU must carry SPS+PPS+IDR so a joining decoder has an entry
+	// point, each NAL prefixed with a start code.
+	if !bytes.Equal(aus[0].au, annexB(sps, pps, idr)) {
+		t.Fatalf("keyframe AU = % x, want SPS+PPS+IDR with start codes", aus[0].au)
+	}
+	if !bytes.Equal(aus[1].au, annexB(p1)) {
+		t.Fatalf("delta AU = % x, want a single P slice", aus[1].au)
+	}
+}
+
+// ffmpeg output arrives in arbitrary chunks, so the splitter must reassemble
+// NALs across read boundaries and never lose or merge one.
+func TestSplitAnnexBReassemblesAcrossChunks(t *testing.T) {
+	idr := nal(5, 0x01, 0x02, 0x03, 0x04, 0x05)
+	p1 := nal(1, 0x06, 0x07)
+	stream := annexB(nal(7, 0x42, 0x00, 0x28), nal(8, 0xCE), idr, p1)
+
+	// A reader that yields one byte at a time is the worst case for a start-code
+	// scanner that assumes whole start codes land in one read.
+	var out bytes.Buffer
+	if err := splitAnnexBToFramed(&iotest1{stream}, &out); err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	aus := parseFramed(t, out.Bytes())
+	if len(aus) != 2 {
+		t.Fatalf("got %d access units across byte-at-a-time reads, want 2", len(aus))
+	}
+	if !aus[0].key || aus[1].key {
+		t.Fatalf("keyframe flags = %v %v, want true false", aus[0].key, aus[1].key)
+	}
+}
+
+// iotest1 is an io.Reader that returns at most one byte per Read.
+type iotest1 struct{ b []byte }
+
+func (r *iotest1) Read(p []byte) (int, error) {
+	if len(r.b) == 0 {
+		return 0, io.EOF
+	}
+	p[0] = r.b[0]
+	r.b = r.b[1:]
+	return 1, nil
+}
+
+func TestFindStartCode(t *testing.T) {
+	// 4-byte start code preceded by content.
+	b := []byte{0xFF, 0x00, 0x00, 0x00, 0x01, 0x67}
+	if idx, l := findStartCode(b, 1); idx != 1 || l != 4 {
+		t.Fatalf("4-byte start code at %d len %d, want 1/4", idx, l)
+	}
+	// 3-byte start code at the head.
+	b = []byte{0x00, 0x00, 0x01, 0x67}
+	if idx, l := findStartCode(b, 0); idx != 0 || l != 3 {
+		t.Fatalf("3-byte start code at %d len %d, want 0/3", idx, l)
+	}
+	if idx, _ := findStartCode([]byte{1, 2, 3, 4}, 0); idx != -1 {
+		t.Fatal("found a start code where there is none")
+	}
+}
+
+// The encoder rejects odd dimensions (4:2:0) and the mirror should not upscale;
+// the target must fit inside maxWidth, keep aspect, and be even.
+func TestFFmpegTargetDims(t *testing.T) {
+	tw, th := ffmpegTargetDims(winInfo{W: 1600, H: 900}, 1100)
+	if tw > 1100 || tw%2 != 0 || th%2 != 0 {
+		t.Fatalf("dims %dx%d: want <=1100 wide and both even", tw, th)
+	}
+	// Aspect preserved within rounding.
+	if r := float64(tw) / float64(th); r < 1.7 || r > 1.8 {
+		t.Fatalf("aspect %.3f drifted from 16:9", r)
+	}
+	// A window already small enough is not upscaled.
+	tw, th = ffmpegTargetDims(winInfo{W: 640, H: 480}, 1100)
+	if tw != 640 || th != 480 {
+		t.Fatalf("dims %dx%d, want the source size unchanged", tw, th)
+	}
+}
+
+// fakeRawBackend is a windowBackend that only knows how to hand back raw frames
+// — enough to drive the ffmpeg helper without a real window. Each frame varies
+// so the encoder produces genuine deltas, not an all-skip stream.
+type fakeRawBackend struct {
+	windowBackend
+	mu    sync.Mutex
+	count int
+}
+
+func (f *fakeRawBackend) captureRaw(w winInfo, tw, th int) ([]byte, error) {
+	f.mu.Lock()
+	f.count++
+	n := f.count
+	f.mu.Unlock()
+	buf := make([]byte, tw*th*4)
+	for i := 0; i < len(buf); i += 4 {
+		buf[i] = byte((i/4 + n*3) % 256) // a band that moves each frame
+		buf[i+1] = byte(n * 7 % 256)
+		buf[i+2] = 0x40
+		buf[i+3] = 0xFF
+	}
+	return buf, nil
+}
+
+// The whole ffmpeg pipeline, for real, where ffmpeg is installed (the Linux
+// VM): capture → rawvideo stdin → encoder → Annex-B stdout → AU framing →
+// winHelper queue. Proves ffmpeg is found and drivable, the encoder produces a
+// stream that starts with a keyframe, and every access unit the consumer sees is
+// a well-formed Annex-B unit tagged H.264 — without a GUI window or TCC.
+func TestFFmpegHelperEncodesEndToEnd(t *testing.T) {
+	if !ffmpegAvailable() {
+		t.Skip("ffmpeg not installed — skipping the live encode test")
+	}
+	b := &fakeRawBackend{}
+	h, err := startFFmpegHelper(b, winInfo{ID: "x", W: 320, H: 240}, 320, 50, 15)
+	if err != nil {
+		t.Fatalf("start ffmpeg helper: %v", err)
+	}
+	defer h.stop()
+
+	gotKey := false
+	frames := 0
+	deadline := time.Now().Add(10 * time.Second)
+	for frames < 5 && time.Now().Before(deadline) {
+		f, ok := h.next(nil, 2*time.Second)
+		if !ok || len(f.Data) == 0 {
+			continue
+		}
+		if !f.H264 {
+			t.Fatal("frame not tagged H.264")
+		}
+		d := f.Data
+		startCode := len(d) >= 4 && d[0] == 0 && d[1] == 0 &&
+			(d[2] == 1 || (d[2] == 0 && d[3] == 1))
+		if !startCode {
+			n := len(d)
+			if n > 8 {
+				n = 8
+			}
+			t.Fatalf("access unit %d does not start with an Annex-B start code: % x", frames, d[:n])
+		}
+		if f.Key {
+			gotKey = true
+		}
+		frames++
+	}
+	if frames < 5 {
+		t.Fatalf("only %d access units within the deadline, want >= 5 (encoder or capture stalled): %s",
+			frames, h.errorText())
+	}
+	if !gotKey {
+		t.Fatal("no keyframe among the first access units — a joining decoder would never sync")
+	}
+}
+
+// scaleExactRGBA (the Wayland raw-capture path's resampler) must always produce
+// exactly dw*dh*4 bytes — ffmpeg's rawvideo input rejects any other size — and
+// preserve a solid color, with an opaque alpha.
+func TestScaleExactRGBA(t *testing.T) {
+	src := image.NewRGBA(image.Rect(0, 0, 100, 60))
+	for i := 0; i < len(src.Pix); i += 4 {
+		src.Pix[i], src.Pix[i+1], src.Pix[i+2], src.Pix[i+3] = 0x20, 0xC0, 0x40, 0xFF
+	}
+	for _, d := range []struct{ w, h int }{{32, 24}, {160, 90}, {17, 13}} {
+		out := scaleExactRGBA(src, d.w, d.h)
+		if len(out) != d.w*d.h*4 {
+			t.Fatalf("scaleExactRGBA to %dx%d = %d bytes, want %d", d.w, d.h, len(out), d.w*d.h*4)
+		}
+		// Middle pixel keeps the source color and an opaque alpha.
+		o := ((d.h/2)*d.w + d.w/2) * 4
+		if out[o] != 0x20 || out[o+1] != 0xC0 || out[o+2] != 0x40 || out[o+3] != 0xFF {
+			t.Fatalf("center pixel = %x %x %x %x, want 20 C0 40 FF", out[o], out[o+1], out[o+2], out[o+3])
+		}
+	}
+}
+
+func TestFFmpegBitrateClamps(t *testing.T) {
+	if br := ffmpegBitrate(64, 64, 30); br != 600_000 {
+		t.Fatalf("tiny window bitrate %d, want the 600k floor", br)
+	}
+	if br := ffmpegBitrate(3840, 2160, 60); br != 12_000_000 {
+		t.Fatalf("huge window bitrate %d, want the 12M ceiling", br)
+	}
+	// A 1100x700 @30 window lands near the macOS helper's measured ~1.7 Mbps.
+	if br := ffmpegBitrate(1100, 700, 30); br < 1_400_000 || br > 2_000_000 {
+		t.Fatalf("1100x700@30 bitrate %d, want ~1.7 Mbps", br)
+	}
+}

--- a/internal/client/capture_helper.go
+++ b/internal/client/capture_helper.go
@@ -102,6 +102,15 @@ type winHelper struct {
 
 	codec string // "jpeg" (default) or "h264" — selects the stdout framing
 
+	// stopFn and keyFn override the default process/stdin teardown and keyframe
+	// request for helpers that are not the macOS reminal-capture process — the
+	// ffmpeg-backed Windows/Linux helper drives its own capture goroutine and
+	// encoder subprocess, and its stdin carries raw pixels, so a literal "key\n"
+	// written there would corrupt the stream. When set they are used instead of
+	// touching cmd/stdin/conn. Nil for the macOS and daemon paths.
+	stopFn func()
+	keyFn  func()
+
 	mu           sync.Mutex
 	latest       []byte     // jpeg: newest frame not yet consumed; nil once taken
 	queue        []winFrame // h264: pending frames in decode order
@@ -381,6 +390,10 @@ func (h *winHelper) rekey() {
 // command channel — stdin when spawned directly, the daemon conn otherwise;
 // the daemon forwards conn bytes to the helper's stdin). Best effort.
 func (h *winHelper) requestKey() {
+	if h.keyFn != nil {
+		h.keyFn()
+		return
+	}
 	if h.conn != nil {
 		_, _ = h.conn.Write([]byte("key\n"))
 		return
@@ -403,6 +416,10 @@ func (h *winHelper) alive() bool {
 // stop kills the helper process and waits for it to reap. Closing stdin first
 // gives it the graceful EOF exit; the Kill is the backstop.
 func (h *winHelper) stop() {
+	if h.stopFn != nil {
+		h.stopFn() // ffmpeg-backed helper: stop its capture goroutine + encoder
+		return
+	}
 	if h.conn != nil {
 		_ = h.conn.Close() // daemon detects the closed conn and stops its helper
 		return

--- a/internal/client/mirror_scroll_test.go
+++ b/internal/client/mirror_scroll_test.go
@@ -300,6 +300,53 @@ func TestApplyWindowInputIsOneImplementation(t *testing.T) {
 	})
 }
 
+// A click used to pay the ~410ms macOS raise (focus walks every window of the
+// app over the Accessibility bridge) on EVERY event — even when the window it
+// targeted was already in front — so clicking around inside one window stuttered
+// though the window never left the front. Clicks now gate on the same
+// front-window tracker scroll uses: raise when the front window changes, never
+// while it stays put. This is half of what makes a remote window feel local.
+func TestClicksRaiseOnlyWhenTheFrontWindowChanges(t *testing.T) {
+	fresh := func() (*recordingBackend, *inputState) {
+		winLookupMu.Lock()
+		winLookupCache = map[string]winLookupEntry{}
+		winLookupMu.Unlock()
+		return &recordingBackend{wins: []winInfo{{ID: "w1", W: 800, H: 600}, {ID: "w2", W: 800, H: 600}}}, &inputState{}
+	}
+
+	t.Run("repeated clicks on one window raise it once", func(t *testing.T) {
+		b, st := fresh()
+		click := windowInput{ID: "w1", Kind: "click", X: 0.5, Y: 0.5, Count: 1}
+		for i := 0; i < 5; i++ {
+			applyWindowInput(b, st, click, nil)
+		}
+		if n := strings.Count(strings.Join(b.calls, " "), "focus"); n != 1 {
+			t.Fatalf("focus called %d times for five clicks on one window, want 1", n)
+		}
+		if n := strings.Count(strings.Join(b.calls, " "), "click("); n != 5 {
+			t.Fatalf("click injected %d times, want all 5 to land", n)
+		}
+	})
+
+	t.Run("a click after a scroll on the same window does not re-raise", func(t *testing.T) {
+		b, st := fresh()
+		applyWindowInput(b, st, windowInput{ID: "w1", Kind: "scroll"}, nil)
+		applyWindowInput(b, st, windowInput{ID: "w1", Kind: "click", Count: 1}, nil)
+		if n := strings.Count(strings.Join(b.calls, " "), "focus"); n != 1 {
+			t.Fatalf("focus called %d times across a scroll then a click on the same window, want 1", n)
+		}
+	})
+
+	t.Run("clicking a different window raises the new one", func(t *testing.T) {
+		b, st := fresh()
+		applyWindowInput(b, st, windowInput{ID: "w1", Kind: "click", Count: 1}, nil)
+		applyWindowInput(b, st, windowInput{ID: "w2", Kind: "click", Count: 1}, nil)
+		if n := strings.Count(strings.Join(b.calls, " "), "focus"); n != 2 {
+			t.Fatalf("focus called %d times, want a raise for each of two different windows", n)
+		}
+	})
+}
+
 // draggingBackend records phased drag injection.
 type draggingBackend struct {
 	recordingBackend

--- a/internal/client/waylandcapture.go
+++ b/internal/client/waylandcapture.go
@@ -92,6 +92,29 @@ func waylandGrabPNG(tool string) ([]byte, error) {
 // output. A region is honored natively by grim; for the file-based tools we grab
 // the whole screen and crop it here.
 func waylandCapture(region *image.Rectangle) ([]byte, error) {
+	img, err := waylandGrabImage(region)
+	if err != nil {
+		return nil, err
+	}
+	return downscaleJPEG(img, winMaxWidth, 55)
+}
+
+// waylandCaptureRaw captures the same way as waylandCapture but returns
+// tightly-packed RGBA at exactly tw×th, for the ffmpeg H.264 helper (see
+// capture_ffmpeg.go). ffmpeg's rawvideo input needs one fixed frame size, so the
+// image is force-scaled to tw×th rather than fit-inside.
+func waylandCaptureRaw(region *image.Rectangle, tw, th int) ([]byte, error) {
+	img, err := waylandGrabImage(region)
+	if err != nil {
+		return nil, err
+	}
+	return scaleExactRGBA(img, tw, th), nil
+}
+
+// waylandGrabImage takes one compositor screenshot (whole screen, or a region)
+// and returns it decoded and cropped — the shared front half of waylandCapture
+// and waylandCaptureRaw.
+func waylandGrabImage(region *image.Rectangle) (image.Image, error) {
 	tool := waylandShotTool()
 	if tool == "" {
 		return nil, fmt.Errorf("no Wayland screenshot tool found — install one of: %s", waylandShotDeps)
@@ -129,7 +152,50 @@ func waylandCapture(region *image.Rectangle) ([]byte, error) {
 			}
 		}
 	}
-	return downscaleJPEG(img, winMaxWidth, 55)
+	return img, nil
+}
+
+// scaleExactRGBA box-averages src to EXACTLY dw×dh and returns tightly-packed
+// RGBA (dw*dh*4 bytes). Like downscaleJPEG's resampling but to a forced size and
+// without the JPEG round-trip — what ffmpeg's rawvideo input consumes.
+func scaleExactRGBA(src image.Image, dw, dh int) []byte {
+	b := src.Bounds()
+	sw, sh := b.Dx(), b.Dy()
+	dst := make([]byte, dw*dh*4)
+	if sw <= 0 || sh <= 0 {
+		return dst
+	}
+	for dy := 0; dy < dh; dy++ {
+		sy0, sy1 := b.Min.Y+dy*sh/dh, b.Min.Y+(dy+1)*sh/dh
+		if sy1 <= sy0 {
+			sy1 = sy0 + 1
+		}
+		for dx := 0; dx < dw; dx++ {
+			sx0, sx1 := b.Min.X+dx*sw/dw, b.Min.X+(dx+1)*sw/dw
+			if sx1 <= sx0 {
+				sx1 = sx0 + 1
+			}
+			var rr, gg, bb, n uint32
+			for y := sy0; y < sy1; y++ {
+				for x := sx0; x < sx1; x++ {
+					r, g, bl, _ := src.At(x, y).RGBA() // 16-bit per channel
+					rr += r >> 8
+					gg += g >> 8
+					bb += bl >> 8
+					n++
+				}
+			}
+			if n == 0 {
+				n = 1
+			}
+			o := (dy*dw + dx) * 4
+			dst[o] = byte(rr / n)
+			dst[o+1] = byte(gg / n)
+			dst[o+2] = byte(bb / n)
+			dst[o+3] = 0xFF
+		}
+	}
+	return dst
 }
 
 // downscaleJPEG box-averages src down to fit within maxW (only shrinking, like

--- a/internal/client/web/index.html
+++ b/internal/client/web/index.html
@@ -8831,6 +8831,15 @@
           ip.liveUntil = performance.now() + 1500;
           dropQueuedFrames(ip);
         }
+        // Peer-to-peer input: when the reliable input channel is up, send the
+        // event straight to the agent over DTLS instead of through the billed
+        // relay. That removes a full Durable-Object round-trip from every click
+        // and keystroke — the change that makes a remote window feel local.
+        // DTLS already protects it, so no app-layer encryption (matching frames
+        // and acks on the other channels). Any failure falls through to WS.
+        if (rtcInput && rtcInput.readyState === 'open') {
+          try { rtcInput.send(JSON.stringify(obj)); return; } catch (_) {}
+        }
       }
       if (!ws || ws.readyState !== WebSocket.OPEN || !cryptoKey) return;
       const frame = { type };
@@ -9663,6 +9672,14 @@
     // the stream, and the pane said the host was asleep. Kept separate so a
     // congested picture can never mute the conversation about it.
     let rtcCtl = null;
+    // The "input" channel: mouse/keyboard/scroll events, viewer→agent. Reliable
+    // and ordered (unlike frames/ctl), because a dropped or reordered input
+    // event leaves the remote in a wrong state — a stuck modifier, a click that
+    // lands before the focus it followed. It exists so input skips the billed WS
+    // relay: an event used to make a full round-trip through the Cloudflare
+    // Durable Object, and that hop was the single biggest reason typing and
+    // clicking felt remote. Falls back to WS whenever it isn't open.
+    let rtcInput = null;
     let rtcRetryAt = 0;  // don't (re)attempt P2P before this time (ms epoch)
     let rtcHelloAt = 0;  // when the current webrtc_hello was sent (to time out silence)
     let rtcRelayed = false; // is the P2P path going through a TURN relay (vs direct)?
@@ -9691,8 +9708,9 @@
     function teardownWebRTC() {
       try { if (rtcDc) rtcDc.close(); } catch (_) {}
       try { if (rtcCtl) rtcCtl.close(); } catch (_) {}
+      try { if (rtcInput) rtcInput.close(); } catch (_) {}
       try { if (rtcPc) rtcPc.close(); } catch (_) {}
-      rtcPc = null; rtcDc = null; rtcCtl = null; rtcPeerId = null; rtcPendingIce = []; rtcRelayed = false;
+      rtcPc = null; rtcDc = null; rtcCtl = null; rtcInput = null; rtcPeerId = null; rtcPendingIce = []; rtcRelayed = false;
     }
     function rtcCtlOpen() { return !!(rtcCtl && rtcCtl.readyState === 'open'); }
     // Inspect the live ICE candidate pair to tell a direct P2P path from a TURN
@@ -9797,6 +9815,15 @@
           };
           ch.onopen = () => { if (DEBUG) dbg('rtc ctl channel open'); };
           ch.onclose = () => { if (rtcCtl === ch) rtcCtl = null; };
+          return;
+        }
+        // The input channel carries events the other way (viewer→agent) and the
+        // agent never sends on it, so there's no onmessage — sendWin just writes
+        // window_input events here instead of the relay while it's open.
+        if (ch.label === 'input') {
+          rtcInput = ch;
+          ch.onopen = () => { if (DEBUG) dbg('rtc input channel open'); };
+          ch.onclose = () => { if (rtcInput === ch) rtcInput = null; };
           return;
         }
         rtcDc = ch;

--- a/internal/client/webrtc.go
+++ b/internal/client/webrtc.go
@@ -159,7 +159,16 @@ type rtcPeer struct {
 	// loop read as a dead viewer and answered by demoting the transport and
 	// then killing the stream ("screen may be locked or asleep" on a host that
 	// was never away). Nil for a v1 viewer, which still acks over dc.
-	ctl       *webrtc.DataChannel
+	ctl *webrtc.DataChannel
+	// in is the v2 input channel: viewer→agent mouse/keyboard/scroll events.
+	// Reliable and ordered (unlike ctl and frames) — a dropped keyup or click
+	// desyncs the remote input state, so this is the one channel that must not
+	// shed messages. It exists to take input OUT of the billed WS relay: input
+	// used to cross the Cloudflare Durable Object on every event, adding a full
+	// relay round-trip to every click and keystroke — the dominant reason a
+	// remote window felt remote rather than local. Nil for a v1 viewer, which
+	// keeps sending input over WS.
+	in        *webrtc.DataChannel
 	v2        bool        // viewer speaks the split-channel protocol
 	h264      bool        // viewer declared WebCodecs H.264 decode in its hello
 	open      atomic.Bool // true once the DataChannel is ready to carry frames
@@ -272,6 +281,26 @@ func (a *Agent) onRTCViewerMsg(peer *rtcPeer, data []byte, viaFrames bool) {
 		a.requestWindowKey(ack.ID)
 	}
 	a.deliverWindowAck(ack.ID, ack.Seq)
+}
+
+// onRTCInput handles one viewer→agent input message off the peer-to-peer input
+// channel. The payload is a plaintext windowInput JSON — DTLS on the
+// DataChannel already gives it the same confidentiality and integrity the WS
+// path gets from app-layer AES-GCM, so it needs no further decryption. It funnels
+// into exactly the same injection path as a relayed window_input, minus the
+// relay round-trip that made every click and keystroke feel remote.
+func (a *Agent) onRTCInput(data []byte) {
+	// Runs in pion's read goroutine on viewer-supplied bytes, outside every
+	// other recover — contain any panic so a crafted message can't crash the
+	// agent.
+	defer func() {
+		if r := recover(); r != nil {
+			recoverLog("input.OnMessage", r)
+		}
+	}()
+	// Copy: pion may reuse the message buffer once this returns, and the darwin
+	// path forwards the bytes to the daemon asynchronously.
+	a.applyInputPayload(append([]byte(nil), data...))
 }
 
 // signal payloads (the JSON inside each webrtc_* message's encrypted Data).
@@ -393,6 +422,19 @@ func (a *Agent) handleWebRTCHello(conn *websocket.Conn, encData string) {
 		if cerr == nil {
 			peer.ctl = ctl
 			ctl.OnMessage(func(m webrtc.DataChannelMessage) { a.onRTCViewerMsg(peer, m.Data, false) })
+		}
+
+		// The input channel: reliable + ordered (the default), the opposite of
+		// frames/ctl. Input must never be dropped or reordered — losing a keyup
+		// leaves a modifier stuck down, and a click landing before its focus
+		// move lands in the wrong place — so this is the one channel that keeps
+		// SCTP's full-reliability contract. Each message is a plaintext
+		// windowInput JSON (DTLS already protects it, exactly like frames), fed
+		// straight into the same injection path the WS relay uses.
+		in, ierr := pc.CreateDataChannel("input", nil)
+		if ierr == nil {
+			peer.in = in
+			in.OnMessage(func(m webrtc.DataChannelMessage) { a.onRTCInput(m.Data) })
 		}
 	}
 

--- a/internal/client/webrtc_input_test.go
+++ b/internal/client/webrtc_input_test.go
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2026 Harshal Gajjar
+
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// Input events used to cross the billed WS relay on every click, scroll and
+// keystroke — a full Cloudflare Durable-Object round-trip that was the dominant
+// reason a remote window felt remote rather than local. They now ride a
+// dedicated reliable+ordered DataChannel straight to the agent over DTLS. This
+// drives a REAL pion connection end to end: the agent offers the input channel
+// exactly as handleWebRTCHello does, the viewer receives it by label and sends a
+// window_input over it, and we prove the event reaches the shared injection path
+// (onRTCInput → applyInputPayload → noteWindowFlush) with no relay in the middle.
+func TestInputChannelDeliversToInjection(t *testing.T) {
+	offerer, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		t.Skipf("no peer connection in this environment: %v", err)
+	}
+	defer offerer.Close()
+	answerer, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		t.Skipf("no peer connection in this environment: %v", err)
+	}
+	defer answerer.Close()
+
+	// The agent side: an input channel wired like the real one. The handler both
+	// records the bytes (so the test can assert delivery on every platform) and
+	// feeds them to the real onRTCInput, which must consume viewer-supplied data
+	// without panicking. The injection that follows onRTCInput is
+	// platform-specific (and no-ops on a headless test box with no desktop), so
+	// it is covered by the applyWindowInput tests, not asserted here.
+	a := &Agent{}
+	got := make(chan []byte, 1)
+	in, err := offerer.CreateDataChannel("input", nil)
+	if err != nil {
+		t.Fatalf("create input channel: %v", err)
+	}
+	if !in.Ordered() {
+		t.Fatal("input channel negotiated unordered — a dropped or reordered event would desync remote input")
+	}
+	in.OnMessage(func(m webrtc.DataChannelMessage) {
+		select {
+		case got <- append([]byte(nil), m.Data...):
+		default:
+		}
+		a.onRTCInput(m.Data) // the real handler must not panic on viewer data
+	})
+
+	// Wire the two ends together directly; no ICE server, no relay.
+	offerer.OnICECandidate(func(c *webrtc.ICECandidate) {
+		if c != nil {
+			_ = answerer.AddICECandidate(c.ToJSON())
+		}
+	})
+	answerer.OnICECandidate(func(c *webrtc.ICECandidate) {
+		if c != nil {
+			_ = offerer.AddICECandidate(c.ToJSON())
+		}
+	})
+
+	// The viewer receives the channel by label (as its ondatachannel does) and
+	// signals once it can send.
+	ready := make(chan *webrtc.DataChannel, 1)
+	answerer.OnDataChannel(func(d *webrtc.DataChannel) {
+		if d.Label() != "input" {
+			return
+		}
+		d.OnOpen(func() { ready <- d })
+	})
+
+	offer, err := offerer.CreateOffer(nil)
+	if err != nil {
+		t.Fatalf("offer: %v", err)
+	}
+	if err := offerer.SetLocalDescription(offer); err != nil {
+		t.Fatalf("set local: %v", err)
+	}
+	if err := answerer.SetRemoteDescription(offer); err != nil {
+		t.Fatalf("set remote: %v", err)
+	}
+	answer, err := answerer.CreateAnswer(nil)
+	if err != nil {
+		t.Fatalf("answer: %v", err)
+	}
+	if err := answerer.SetLocalDescription(answer); err != nil {
+		t.Fatalf("answer set local: %v", err)
+	}
+	if err := offerer.SetRemoteDescription(answer); err != nil {
+		t.Fatalf("answer set remote: %v", err)
+	}
+
+	var vch *webrtc.DataChannel
+	select {
+	case vch = <-ready:
+	case <-time.After(15 * time.Second):
+		t.Skip("input channel did not open in this environment")
+	}
+
+	// A scroll (not a click) keeps the payload off the context-menu path; the
+	// fake window id resolves to nothing downstream, so nothing is ever injected
+	// — the point is that the exact bytes traverse the reliable input channel to
+	// the agent.
+	payload := `{"id":"w1","kind":"scroll","x":0.5,"y":0.5,"dx":0,"dy":-3}`
+	if err := vch.SendText(payload); err != nil {
+		t.Fatalf("viewer send over input channel: %v", err)
+	}
+
+	select {
+	case b := <-got:
+		if string(b) != payload {
+			t.Fatalf("agent received %q over the input channel, want %q", b, payload)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("input event never reached the agent over the DataChannel")
+	}
+}

--- a/internal/client/winbackend_win32_capture.go
+++ b/internal/client/winbackend_win32_capture.go
@@ -146,6 +146,82 @@ func w32Downscale(src *image.RGBA, maxW int) *image.RGBA {
 	return dst
 }
 
+// w32ScaleExact box-averages src to EXACTLY dw×dh (not fit-inside). The ffmpeg
+// H.264 helper needs frames at one fixed size — its rawvideo input rejects a
+// changed byte count — and ffmpegTargetDims already chose dw×dh to match the
+// window's aspect, so this only resamples, it does not distort beyond that
+// rounding. Upscaling (a window smaller than the target) samples nearest.
+func w32ScaleExact(src *image.RGBA, dw, dh int) *image.RGBA {
+	sw, sh := src.Rect.Dx(), src.Rect.Dy()
+	dst := image.NewRGBA(image.Rect(0, 0, dw, dh))
+	if sw == 0 || sh == 0 {
+		return dst
+	}
+	for dy := 0; dy < dh; dy++ {
+		y0, y1 := dy*sh/dh, (dy+1)*sh/dh
+		if y1 <= y0 {
+			y1 = y0 + 1
+		}
+		for dx := 0; dx < dw; dx++ {
+			x0, x1 := dx*sw/dw, (dx+1)*sw/dw
+			if x1 <= x0 {
+				x1 = x0 + 1
+			}
+			var r, g, b, n uint32
+			for y := y0; y < y1; y++ {
+				row := src.Pix[y*src.Stride:]
+				for x := x0; x < x1; x++ {
+					r += uint32(row[x*4])
+					g += uint32(row[x*4+1])
+					b += uint32(row[x*4+2])
+					n++
+				}
+			}
+			o := dy*dst.Stride + dx*4
+			dst.Pix[o] = byte(r / n)
+			dst.Pix[o+1] = byte(g / n)
+			dst.Pix[o+2] = byte(b / n)
+			dst.Pix[o+3] = 0xFF
+		}
+	}
+	return dst
+}
+
+// w32CaptureRGBA grabs one frame as a full-resolution (cropped) RGBA image — the
+// shared step behind both the JPEG mirror (capture) and the raw H.264 feed
+// (captureRaw). PrintWindow first (captures occluded/DWM content), BitBlt of the
+// screen rect as the all-black fallback.
+func w32CaptureRGBA(w winInfo) (*image.RGBA, error) {
+	if isDisplayID(w.ID) {
+		return w32BitBltScreen(w.X, w.Y, w.W, w.H)
+	}
+	hwnd, err := w32ParseHWND(w.ID)
+	if err != nil {
+		return nil, err
+	}
+	frame, ok := w32FrameBounds(hwnd)
+	if !ok {
+		frame, _ = w32WindowRect(hwnd)
+	}
+	if img, ok := w32PrintWindowRGBA(hwnd, frame); ok {
+		return img, nil
+	}
+	return w32BitBltScreen(w.X, w.Y, w.W, w.H)
+}
+
+// captureRaw returns one frame as tightly-packed RGBA at exactly tw×th, for the
+// ffmpeg H.264 helper (see capture_ffmpeg.go).
+func (win32Windows) captureRaw(w winInfo, tw, th int) ([]byte, error) {
+	rgba, err := w32CaptureRGBA(w)
+	if err != nil {
+		return nil, err
+	}
+	scaled := w32ScaleExact(rgba, tw, th)
+	// image.NewRGBA(0,0,tw,th) is tightly packed (Stride == 4*tw), so Pix is
+	// already exactly tw*th*4 bytes of RGBA — what ffmpeg's rawvideo wants.
+	return scaled.Pix, nil
+}
+
 // w32EncodeFrame downscales and JPEG-encodes a captured frame.
 func w32EncodeFrame(img *image.RGBA) ([]byte, error) {
 	var buf bytes.Buffer
@@ -195,6 +271,18 @@ func w32BitBltScreen(x, y, w, h int) (*image.RGBA, error) {
 // then cropped to the DWM frame bounds so pixels line up 1:1 with the rect we
 // enumerate and map clicks against. ok=false → caller falls back to BitBlt.
 func w32PrintWindowCapture(hwnd uintptr, frame w32Rect) ([]byte, bool) {
+	rgba, ok := w32PrintWindowRGBA(hwnd, frame)
+	if !ok {
+		return nil, false
+	}
+	img, err := w32EncodeFrame(rgba)
+	return img, err == nil
+}
+
+// w32PrintWindowRGBA is w32PrintWindowCapture returning the cropped RGBA instead
+// of a JPEG, so the raw H.264 feed can reuse it. ok=false → caller falls back to
+// BitBlt.
+func w32PrintWindowRGBA(hwnd uintptr, frame w32Rect) (*image.RGBA, bool) {
 	wr, ok := w32WindowRect(hwnd)
 	if !ok {
 		return nil, false
@@ -232,33 +320,11 @@ func w32PrintWindowCapture(hwnd uintptr, frame w32Rect) ([]byte, bool) {
 	if crop.Empty() {
 		crop = image.Rect(0, 0, fullW, fullH)
 	}
-	img, err := w32EncodeFrame(w32BGRAToRGBA(bits, fullW, crop))
-	return img, err == nil
+	return w32BGRAToRGBA(bits, fullW, crop), true
 }
 
 func (win32Windows) capture(w winInfo) ([]byte, error) {
-	if isDisplayID(w.ID) {
-		// Whole desktop: blt the monitor rect straight off the screen DC.
-		rgba, err := w32BitBltScreen(w.X, w.Y, w.W, w.H)
-		if err != nil {
-			return nil, err
-		}
-		return w32EncodeFrame(rgba)
-	}
-	hwnd, err := w32ParseHWND(w.ID)
-	if err != nil {
-		return nil, err
-	}
-	frame, ok := w32FrameBounds(hwnd)
-	if !ok {
-		frame, _ = w32WindowRect(hwnd)
-	}
-	if img, ok := w32PrintWindowCapture(hwnd, frame); ok {
-		return img, nil
-	}
-	// PrintWindow failed or drew all-black — grab the window's screen rect
-	// instead (loses occluded content, but always shows what the user sees).
-	rgba, err := w32BitBltScreen(w.X, w.Y, w.W, w.H)
+	rgba, err := w32CaptureRGBA(w)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/windows.go
+++ b/internal/client/windows.go
@@ -507,12 +507,22 @@ func (a *Agent) updateMenuState(plaintext []byte) {
 	a.winMu.Unlock()
 }
 
-// handleWindowInput injects a mouse/keyboard event into the target window.
+// handleWindowInput injects a mouse/keyboard event that arrived over the billed
+// WS relay (encrypted). The peer-to-peer input channel bypasses this and calls
+// applyInputPayload directly with the already-plaintext bytes (see onRTCInput).
 func (a *Agent) handleWindowInput(encData string) {
 	plaintext, err := a.box.Decrypt(encData)
 	if err != nil {
 		return
 	}
+	a.applyInputPayload(plaintext)
+}
+
+// applyInputPayload injects one decrypted window_input event into its target
+// window. Shared by the WS relay path (handleWindowInput) and the peer-to-peer
+// input channel (onRTCInput) so both roads inject identically — the only
+// difference is that P2P skips the relay hop and the decrypt.
+func (a *Agent) applyInputPayload(plaintext []byte) {
 	if runtime.GOOS == "darwin" {
 		// Inject in the daemon (sh.reminal) so one grant covers Accessibility +
 		// Automation for every session, terminal or "+". Runs on the serialized
@@ -1099,8 +1109,15 @@ func applyWindowInput(b windowBackend, st *inputState, ev windowInput, noteMenu 
 			count = winMaxClickCount
 		}
 		right := ev.Button == "right"
-		_ = b.focus(w)
-		st.front.note(ev.ID)
+		// Raise only when this isn't already the front window. A click used to
+		// pay the raise (≈410ms on macOS — see frontWindowTracker) every single
+		// time, so clicking around inside one window stuttered even though the
+		// window never left the front. Scroll already gates on needsRaise; clicks
+		// and drags now do too, which is the difference between a window that
+		// responds to a click at local speed and one that pauses before each.
+		if st.front.needsRaise(ev.ID) {
+			_ = b.focus(w)
+		}
 		_ = b.clickN(w, ev.X, ev.Y, count, right)
 		if noteMenu != nil {
 			noteMenu(w, right)
@@ -1111,8 +1128,9 @@ func applyWindowInput(b windowBackend, st *inputState, ev windowInput, noteMenu 
 		case ev.Phase == "":
 			// The viewer buffered the gesture and sent it after the pointer
 			// lifted; replayed at scripted speed.
-			_ = b.focus(w)
-			st.front.note(ev.ID)
+			if st.front.needsRaise(ev.ID) {
+				_ = b.focus(w)
+			}
 			_ = b.drag(w, clampPath(ev.Path, winMaxPathPoints))
 		case !phased:
 			// This backend never advertised drag_phases, so a phased event
@@ -1120,8 +1138,9 @@ func applyWindowInput(b windowBackend, st *inputState, ev windowInput, noteMenu 
 			// once per chunk — a burst of clicks, not a drag.
 			return
 		case ev.Phase == "begin":
-			_ = b.focus(w)
-			st.front.note(ev.ID)
+			if st.front.needsRaise(ev.ID) {
+				_ = b.focus(w)
+			}
 			_ = pd.dragPhase(w, "down", ev.X, ev.Y)
 			st.dragWatch(pd, w, ev.X, ev.Y)
 		case ev.Phase == "move":

--- a/internal/client/windows.go
+++ b/internal/client/windows.go
@@ -1944,15 +1944,23 @@ func (a *Agent) releaseWindowInput() {
 	_ = a.windows().releaseInput()
 }
 
-// startCaptureHelper returns the frame source for a window. On macOS it dials the
-// daemon's mirror service — so ALL capture runs in the one granted sh.reminal
-// process and a single reminal.app grant covers every session (terminal or "+");
-// elsewhere it spawns the capture helper directly.
-func startCaptureHelper(id string, maxWidth, quality, fps int, codec string) (*winHelper, error) {
+// startCaptureHelper returns the frame source for this stream's window. On macOS
+// it dials the daemon's mirror service — so ALL capture runs in the one granted
+// sh.reminal process and a single reminal.app grant covers every session
+// (terminal or "+"). On Windows and Linux, an h264 stream captures in Go and
+// encodes through ffmpeg (startFFmpegHelper); a jpeg stream has no helper there
+// (startWinHelper is macOS-only), so it returns an error and the stream serves
+// screenshots from the backend directly — the behaviour those platforms have
+// always had.
+func (s *winStream) startCaptureHelper(fps int, codec string) (*winHelper, error) {
+	maxWidth, quality := s.profile.MaxWidth, s.profile.Quality
 	if runtime.GOOS == "darwin" {
-		return startMirrorCapture(id, maxWidth, quality, fps, codec)
+		return startMirrorCapture(s.w.ID, maxWidth, quality, fps, codec)
 	}
-	return startWinHelper(id, maxWidth, quality, fps, codec)
+	if codec == "h264" {
+		return startFFmpegHelper(s.b, s.w, maxWidth, quality, fps)
+	}
+	return startWinHelper(s.w.ID, maxWidth, quality, fps, codec)
 }
 
 // ensureHelper keeps the native capture helper alive: reaps one that died and
@@ -1995,7 +2003,7 @@ func (s *winStream) ensureHelper() {
 	if time.Now().Before(s.helperRetryAt) {
 		return
 	}
-	h, err := startCaptureHelper(s.w.ID, s.profile.MaxWidth, s.profile.Quality, s.captureFPS(), s.codec)
+	h, err := s.startCaptureHelper(s.captureFPS(), s.codec)
 	if err == nil {
 		s.helper = h
 		s.helperErr = ""
@@ -2028,7 +2036,7 @@ func (s *winStream) ensureHelper() {
 		// unavailable). Fall back to JPEG immediately — the viewer is waiting
 		// for frames — and re-test h264 once the suspension lapses.
 		s.suspendH264()
-		if h, jerr := startCaptureHelper(s.w.ID, s.profile.MaxWidth, s.profile.Quality, winHelperFPS, ""); jerr == nil {
+		if h, jerr := s.startCaptureHelper(winHelperFPS, ""); jerr == nil {
 			s.helper = h
 			s.helperErr = ""
 			s.helperStarted = time.Now()
@@ -2185,7 +2193,7 @@ func (s *winStream) checkWindow(conn *websocket.Conn, changed bool) bool {
 		if resized && s.helper != nil {
 			s.helper.stop()
 			s.helper = nil
-			if h, err := startCaptureHelper(s.w.ID, s.profile.MaxWidth, s.profile.Quality, s.captureFPS(), s.codec); err == nil {
+			if h, err := s.startCaptureHelper(s.captureFPS(), s.codec); err == nil {
 				s.helper = h
 			} else {
 				s.helperRetryAt = time.Now().Add(helperRetryCooldown)

--- a/internal/client/windows_backends.go
+++ b/internal/client/windows_backends.go
@@ -976,6 +976,43 @@ func (linuxWindows) captureRegion(x, y, w, h int) ([]byte, error) {
 		"-resize", box, "-quality", "55", "jpg:-")
 }
 
+// captureRaw grabs one frame as tightly-packed RGBA at exactly tw×th, for the
+// ffmpeg H.264 helper (see capture_ffmpeg.go). It follows the same Wayland/X11
+// split as capture(): a compositor screenshot on Wayland (where an X11 grab is
+// black), else ImageMagick's raw RGBA output. Either way the resize is forced to
+// the exact size ffmpeg's fixed-size rawvideo input demands (the "!" flag / an
+// exact rescale) — a resized window renders scaled until the stream restarts the
+// helper, never a byte count that desyncs the encoder.
+func (linuxWindows) captureRaw(w winInfo, tw, th int) ([]byte, error) {
+	if isWaylandSession() {
+		if isDisplayID(w.ID) {
+			return waylandCaptureRaw(nil, tw, th)
+		}
+		r := image.Rect(w.X, w.Y, w.X+w.W, w.Y+w.H)
+		return waylandCaptureRaw(&r, tw, th)
+	}
+	if !have("import") {
+		return nil, fmt.Errorf("install imagemagick (provides `import`) to capture windows")
+	}
+	args := []string{"-window", w.ID}
+	if isDisplayID(w.ID) {
+		args = []string{"-window", "root"}
+	}
+	if w.CropL > 0 || w.CropT > 0 {
+		args = append(args, "-crop",
+			fmt.Sprintf("%dx%d+%d+%d", w.W, w.H, w.CropL, w.CropT), "+repage")
+	}
+	args = append(args, "-resize", fmt.Sprintf("%dx%d!", tw, th), "-depth", "8", "RGBA:-")
+	pix, err := runRaw("import", args...)
+	if err != nil {
+		return nil, err
+	}
+	if want := tw * th * 4; len(pix) != want {
+		return nil, fmt.Errorf("import returned %d bytes, want %d for %dx%d RGBA", len(pix), want, tw, th)
+	}
+	return pix, nil
+}
+
 func (linuxWindows) focus(w winInfo) error {
 	if isDisplayID(w.ID) {
 		return nil // a desktop has no window to raise; clicks land wherever aimed


### PR DESCRIPTION
Makes a remote window feel like it's running locally, on the input path and the video path.

## #1 — Input latency
- **Input over a dedicated P2P DataChannel.** Clicks, scroll, and keystrokes used to cross the billed Cloudflare relay (a full Durable-Object round-trip per event). They now ride a reliable, ordered WebRTC `input` channel straight to the agent over DTLS, falling back to WS when P2P isn't up.
- **Raise-skip.** Clicks and drags paid the ~410 ms macOS `focus()` raise on *every* event; they now gate on the same `frontWindowTracker` scroll already used, so interacting inside one window no longer re-raises it.

## #2 — Cross-platform H.264
- Windows and Linux window mirrors were plain JPEG (~15–40 Mbps). They now encode H.264 via ffmpeg — Media Foundation (`h264_mf`) on Windows, VAAPI/libx264 on Linux — re-framed into the exact `[len][flag][AU]` shape the macOS helper emits, so transport/viewer are unchanged. Clean JPEG fallback when ffmpeg is absent. Main profile, matching the viewer's `avc1.4d0028`.

## Testing
- Real-pion input-channel e2e + raise-skip: host + macOS/Linux/Windows VMs.
- ffmpeg encode pipeline e2e: Linux VM (libx264) and Windows VM (`h264_mf`, Media Foundation), Main-profile keyframe-first output.
- Live capture + injection on the macOS VM (signed build, TCC granted): typed input drove a real app and changed the captured frames.
- Full `internal/client` + `internal/relay` suites, `go vet`, and darwin/linux/windows cross-builds all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTuEP3rbw5DeGSpBgEbbat