### PR TITLE
install.ps1: don't abort when Documents (MyDocuments) resolves empty

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -172,10 +172,19 @@ try {
 } catch {}
 $end
 "@
+    # GetFolderPath("MyDocuments") returns "" on some configurations (a redirected
+    # or not-yet-created Documents folder, the SYSTEM profile), which made the
+    # Join-Path below throw "Cannot bind argument to parameter 'Path' because it
+    # is an empty string" and — since it sat OUTSIDE the best-effort try — abort
+    # the whole install with $ErrorActionPreference=Stop, even though reminal.exe
+    # and PATH were already in place. Fall back to %USERPROFILE%\Documents, and
+    # build $prof INSIDE the try so a bad path can never fail the install.
     $docs = [Environment]::GetFolderPath("MyDocuments")
+    if (-not $docs) { $docs = Join-Path $env:USERPROFILE "Documents" }
     foreach ($profDir in @("WindowsPowerShell", "PowerShell")) {
-        $prof = Join-Path (Join-Path $docs $profDir) "profile.ps1"
         try {
+            if (-not $docs) { continue }
+            $prof = Join-Path (Join-Path $docs $profDir) "profile.ps1"
             New-Item -ItemType Directory -Force -Path (Split-Path $prof) | Out-Null
             $existing = if (Test-Path $prof) { Get-Content $prof -Raw } else { "" }
             # Strip any previously-managed block so re-running rewrites exactly one.
@@ -210,7 +219,9 @@ if ($userPath) {
 }
 # profile blocks
 $docs = [Environment]::GetFolderPath("MyDocuments")
+if (-not $docs) { $docs = Join-Path $env:USERPROFILE "Documents" }
 foreach ($profDir in @("WindowsPowerShell", "PowerShell")) {
+    if (-not $docs) { continue }
     $prof = Join-Path (Join-Path $docs $profDir) "profile.ps1"
     if (Test-Path $prof) {
         $existing = Get-Content $prof -Raw


### PR DESCRIPTION
**Bug (reported on several Windows machines):** `irm https://reminal.app/install.ps1 | iex` fails with `Cannot bind argument to parameter 'Path' because it is an empty string` right after "Downloading…".

**Cause:** `[Environment]::GetFolderPath("MyDocuments")` returns `""` on some configs (redirected / not-yet-created Documents, or SYSTEM profile). `Join-Path (Join-Path $docs $profDir) "profile.ps1"` then throws — and that line was **outside** the best-effort `try`, so with `$ErrorActionPreference=Stop` it aborted the whole install. reminal.exe + PATH were already installed, so it looked like a failure but had mostly succeeded.

**Fix:** fall back to `%USERPROFILE%\Documents` when MyDocuments is empty, and build `$prof` **inside** the `try` (skip if still empty), so profile setup can never fail the install. Same guard in the embedded uninstaller.

**Verified** on a Windows VM (empty MyDocuments): the exact `irm | iex` now completes cleanly — profile written via the fallback, `reminal.exe` installed and running `version`.

Served installer = `main` (reminal.app/install.ps1 302 → raw githubusercontent main), so **merging fixes it live** — no release/deploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)